### PR TITLE
fix: silent audio + truncated duration

### DIFF
--- a/remotion/remotion.config.ts
+++ b/remotion/remotion.config.ts
@@ -1,4 +1,5 @@
 import { Config } from "@remotion/cli/config";
 
 Config.setVideoImageFormat("jpeg");
-Config.setPublicDir("../workspace");
+// publicDir is set per-render via the --public-dir CLI flag in scripts/render.sh
+// (each example has its own workspace/ folder, so a static config value won't work).

--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { Composition, AbsoluteFill, Sequence, Audio, staticFile } from "remotion";
+import {
+  Composition,
+  AbsoluteFill,
+  Sequence,
+  Audio,
+  staticFile,
+} from "remotion";
 import { CoverSlide } from "./compositions/CoverSlide";
 import { TextSlide } from "./compositions/TextSlide";
 import { CodeSlide } from "./compositions/CodeSlide";
@@ -72,13 +78,18 @@ const DEFAULT_METADATA: Metadata = {
       type: "code",
       durationInFrames: 90,
       language: "ts",
-      code: 'const video = await kit.render(script);',
+      code: "const video = await kit.render(script);",
     },
   ],
 };
 
-const Main: React.FC<{ metadata?: Metadata }> = ({ metadata }) => {
-  const meta = metadata ?? DEFAULT_METADATA;
+/**
+ * Main receives the Metadata directly as its props (not wrapped in a
+ * `metadata` key), which matches what scripts/build-metadata.mjs writes
+ * to <project>/metadata.json. The CLI flag --props=<json> sets the entire
+ * props object of this component.
+ */
+const Main: React.FC<Metadata> = (meta) => {
   let offset = 0;
   return (
     <AbsoluteFill style={{ backgroundColor: "#0b0b0f" }}>
@@ -116,17 +127,28 @@ const calcDuration = (m: Metadata) =>
   m.slides.reduce((acc, s) => acc + s.durationInFrames, 0);
 
 export const Root: React.FC = () => {
-  const meta = DEFAULT_METADATA;
   return (
     <Composition
       id="Main"
       component={Main}
-      durationInFrames={calcDuration(meta)}
-      fps={meta.fps}
-      width={meta.width}
-      height={meta.height}
-      defaultProps={{ metadata: meta }}
-      // When rendering via CLI, pass --props=metadata.json to override.
+      // Placeholders; calculateMetadata reads the real values from props
+      // (the entire props object IS the Metadata, set via --props=<json>
+      // from scripts/render.sh).
+      durationInFrames={1}
+      fps={30}
+      width={1080}
+      height={1920}
+      defaultProps={DEFAULT_METADATA}
+      calculateMetadata={({ props }) => {
+        const meta: Metadata = props.slides ? props : DEFAULT_METADATA;
+        return {
+          durationInFrames: calcDuration(meta),
+          fps: meta.fps,
+          width: meta.width,
+          height: meta.height,
+          props: meta,
+        };
+      }}
     />
   );
 };

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -30,8 +30,11 @@ node "$KIT_ROOT/scripts/build-metadata.mjs" "$PROJECT"
 echo "▶ [4/4] Remotion render"
 mkdir -p "$PROJECT/out"
 cd "$KIT_ROOT/remotion"
-npx remotion render src/index.ts Main "$PROJECT/out/full.mp4" \
-  --props="$PROJECT/metadata.json" \
+# Note: Remotion v4 --props expects either inline JSON or doesn't auto-load
+# file paths reliably. We pass file content via $(cat) so the JSON is inlined.
+PROPS_JSON="$(cat "$PROJECT/metadata.json")"
+./node_modules/.bin/remotion render src/index.ts Main "$PROJECT/out/full.mp4" \
+  --props="$PROPS_JSON" \
   --public-dir="$PROJECT/workspace"
 
 echo "✅ done → $PROJECT/out/full.mp4"


### PR DESCRIPTION
4 connected bugs causing rendered mp4 to be silent and clipped. All fixed and verified end-to-end. See commit message for details.