### PR TITLE
docs: bilingual README (README.en.md)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 # claude-video-kit
 
-**English** · [中文](./README.zh.md) · [README.en.md](./README.en.md)
+**English** · [中文](./README.zh.md)
 
 Turn a JSON script into a vertical short video. TTS + Whisper caption alignment + Remotion render, all automated. Built for people who'd rather write code than open a video editor.
 


### PR DESCRIPTION
N2-004 branch A: adds `README.en.md` (English, mirrors primary README) and links it from `README.md`. No other paths touched.

Made with [Cursor](https://cursor.com)