### PR TITLE
shorts pipeline: Step 1.5 / 5.5 / Step 7 + Karpathy #1 ref + Bilibili API direct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ remotion/public/captions.json
 # Distribute outputs (Leo-specific content; do not commit to upstream)
 examples/*/distribute/
 examples/*/distribute.zip
+.env

--- a/docs/SHORTS_PIPELINE.md
+++ b/docs/SHORTS_PIPELINE.md
@@ -60,6 +60,33 @@ to X (Leo manual), then Claude re-publishes the local mp4 to YouTube via
 }
 ```
 
+### 结尾 slide 模板（P0 强制 · 2026-04-30 立）
+
+每个 shorts 必须以两个 slide 结尾：
+
+1. **倒数第二**：内容金句（本期主题相关，可变）
+2. **最后**：品牌签名 cover（**固定模板，不可变**）
+
+```jsonc
+{
+  "type": "cover",
+  "title": "@runes_leo · leolabs.me",
+  "subtitle": "AI × Crypto 独立构建者",
+  "eyebrow": "Learn in public, Build in public",
+  "accentColor": "#f59e0b",
+  "voice_text": "我是 Leo，做 AI 和加密的独立构建者。在 Polymarket 做量化，用 Claude Code 搭数据和自动化系统。更多在 leolabs.me，下次见。",
+  "caption_text": "Polymarket 量化 · Claude Code 搭系统 · leolabs.me"
+}
+```
+
+参考 `~/Projects/leo-vault/domains/内容创作/_SOP-文章尾部模板.md` 文章版结尾 SSOT。
+
+**禁止**：
+- 用最后一帧给外部大佬 / 源头视频引流（流量送给别人）
+- 每条视频重新发明结尾文案（品牌识别一致性靠模板）
+
+**外部链接路由**：评论区跟推 + 各平台描述里都可放，不挤进视频帧。
+
 ### voice_text 写作准则（P0 强制）
 
 1. **逻辑自洽**：不引用前文没出现的数字。视频文稿"裸读"也要从头到尾结构清晰。
@@ -89,7 +116,28 @@ modal run scripts/modal_tts_batch.py --project examples/<name>
 
 读 `script.json` → 每 slide 的 `voice_text` 走 IndexTTS2 → 写入 `examples/<name>/workspace/NN.wav`（10 条 ~3min）。
 
-**注**: 脚本不支持 skip-if-exists，单条改动也要全跑。要省时间可改 `voice_text` 后只跑变动条目（手动管理 wav 文件名）。
+### `_good/` wav 复用机制（2026-04-30 立）
+
+IndexTTS2 是非确定性的（sampling temperature）。同样的 voice_text 可能这次念对英文下次念错。**工作流**：
+
+1. 跑 modal_tts → 听一遍
+2. 念对的 slide cp 到 `_good/`：`cp workspace/NN.wav workspace/_good/NN.wav`
+3. 重跑 modal_tts → 自动跳过 `_good/` 里有的 slide，只重跑念错的
+4. 重复直到全部 mark good。从此这条视频再跑 modal cost = 0
+
+`modal_tts_batch.py` 启动时检查 `workspace/_good/<NN>.wav`，存在则直接复用 + 跳过该 slide 的 modal 调用。
+
+### `PRONUNCIATION_FIXES` 字典
+
+`modal_tts_batch.py` 顶部的预处理 dict，在送 IndexTTS2 前替换文本（原 `voice_text` 不动，align/caption 仍用原文）。处理稳定可知的发音问题：
+
+```python
+PRONUNCIATION_FIXES = [
+    ("leolabs.me", "leolabs点 me"),  # 域名 "." 当中文句号读错节奏
+]
+```
+
+撞到新发音错的词加一行。**注意**：英文字母组合（如 "AI"）不要加这里——音译"诶艾"/"人工智能"都不自然，靠 `_good/` 多次跑选对的版本。
 
 ---
 
@@ -99,17 +147,20 @@ modal run scripts/modal_tts_batch.py --project examples/<name>
 cd workspace && mkdir -p _orig && cp [0-9]*.wav _orig/
 for f in [0-9]*.wav; do
   ffmpeg -y -i _orig/$f \
-    -af "silenceremove=stop_periods=-1:stop_duration=0.2:stop_threshold=-40dB,loudnorm=I=-14:TP=-1.5:LRA=11" \
-    -ar 24000 $f
+    -af "areverse,silenceremove=start_periods=1:start_silence=0.3:start_threshold=-40dB,areverse,loudnorm=I=-14:TP=-1.5:LRA=11" \
+    -ar 24000 /tmp/out_$f
+  mv /tmp/out_$f $f
 done
 ```
 
 **两个滤镜不可省**：
 
-- `silenceremove=stop_periods=-1:stop_duration=0.2:stop_threshold=-40dB` — 切**尾部** silence/noise tail。否则 IndexTTS2 末尾的低电平 "shhh" 噪音会被 loudnorm 放大听得见。
-- `loudnorm=I=-14:TP=-1.5:LRA=11` — 标准化到 -14 LUFS / -1.5 dBTP。这是 YouTube / X / 抖音 / 小红书统一标准。直接用 IndexTTS2 原始输出 mean ~-35 dB 太小，手机外放听不清。
+- `areverse → silenceremove start_periods=1 → areverse` — 标准的"只切尾部静音"模式。**不要用 `stop_periods=-1`**（会切所有静音段，吞掉句子之间的自然停顿，2026-04-30 Leo 实测 slide 01 被切 41% 时长）。原理：反转音频让尾部变开头，切第一个静音段，再反转回来。
+- `loudnorm=I=-14:TP=-1.5:LRA=11` — 标准化到 -14 LUFS / -1.5 dBTP。YouTube / X / 抖音 / 小红书统一标准。
 
-**常见坑**：不要加 `afade=t=out:d=0.001:duration=0` — 这是 invalid syntax，会让 ffmpeg 把整段音频 fade 到 0（mean -78dB ≈ 静音）。
+**常见坑**：
+- 不要加 `afade=t=out:d=0.001:duration=0` — invalid syntax，会让 ffmpeg 把整段音频 fade 到 0（mean -78dB ≈ 静音）。
+- 不要用 `stop_periods=-1` — 切所有静音段而非只尾部，吞中间停顿。
 
 **验证**：
 ```bash
@@ -274,6 +325,40 @@ preset: "long"    →  1920×1080 / 30fps / fontScale=0.9 / max 7200s（Phase 3 
 
 ---
 
+## Step 5.5 · 审核 stop 门（P0 强制 · 2026-04-30 立）
+
+**Render 后必须 Leo 审视频，禁自动进 Step 6 分发链**。流程：
+
+1. `open <project>/out/full.mp4` 给 Leo 审
+2. 等明确"OK / 通过 / 发布"等确认词
+3. 通过 → Step 6 分发包 + Step 7 各平台发布
+4. 不通过 → 回上游修（script.json / voice_text / slide）→ 重跑
+
+**禁止**：render 完直接调 youtube/upload.py 或 push X / TG / B 站。
+**违规事件**：2026-04-30 第一次跑通 #10 视频，render 后直接调 youtube unlisted upload，被 Leo 当场叫停（output 0 byte 没真传）。
+
+---
+
+## 画面素材决策树（按视频类型自动选）
+
+| 视频类型 | 默认画面 | 回避 |
+|---------|---------|------|
+| **反常识科普 / AI 翻车 demo** | 屏幕录制实际翻车 + 文字卡叠原理（30min 出片） | 纯文字卡（信号低）/ 大佬视频片段（版权 + 剪辑成本） |
+| **工具 demo / Build in Public** | 屏幕录制完整流程 + 文字卡叠步骤 | 抽象动画 |
+| **观点 / 冷思考** | 文字卡为主 + 必要数据图 | 屏幕录制（无可演示对象） |
+
+## CTA 决策树（按资产可用性自动选）
+
+```
+1. 自家 Article / Repo / Skill 已发布 → 链接到自家资产
+2. 自家 Article / Repo 已规划但未发布 → "完整版评论区 / 钉推即将更新"
+3. 都没有 → 引用源头大佬链接（信用资产，放评论区）+ pin 自己最近相关推
+```
+
+视频里**最后一帧**永远是品牌签名 cover（见 Step 1 §结尾 slide 模板），不是任何外部链接。
+
+---
+
 ## Step 6 · 分发包 + 网盘上传（定稿后强制）
 
 视频本体定稿（Leo 验收 OK）后**必须立即做**这一步，禁拖延、禁跳：
@@ -366,6 +451,11 @@ Shorts viral norm：
 | 10 | 字幕被强制切 4 行 | wrap `targetPerLine + 2` + 强制 merge 第 4 行回第 3 行 |
 | 11 | 文稿提"95%"前文没出现 → 观众一脸懵 | voice_text 准则：逻辑自洽，裸读能懂 |
 | 12 | 没 verify 引用就让 Leo 返工 | 写内容前先 grep 历史研究记录（P0 `pattern_recall_leo_history_before_content`）|
+| 13 | `silenceremove stop_periods=-1` 切所有静音段（吞中间停顿，slide 01 被切 41%） | 改用 `areverse → silenceremove start_periods=1 start_silence=0.3 → areverse` 只切尾部 |
+| 14 | `align.py` 用字符比例分配时间，对 voice_text 含英文专有名词时严重错位 | 新算法 `captions_from_script_whisper_aligned`：whisper word-timestamp 给 timing + voice_text 给文字。`--legacy-char-ratio` 退回旧逻辑 |
+| 15 | `split_by_punct` 切 "9.11" / "leolabs.me" 的 `.` → 字幕显示成 "9", "11" | 正则加 lookahead/lookbehind：`(?<![\w\d])\.|\.(?![\w\d])`，前后是字母数字的 `.` 不切 |
+| 16 | IndexTTS2 把 "AI" 不稳定读成 "A1"/"I1"，多次跑结果不同 | `_good/<NN>.wav` 复用机制：跑对的 wav cp 到 `_good/`，下次自动跳过 modal。配 `PRONUNCIATION_FIXES` dict 处理域名 `.` 等稳定问题 |
+| 17 | 视频结尾用"Karpathy 视频原链接评论区"给外部大佬引流 | P0 强制结尾 cover 模板（@runes_leo / leolabs.me / Polymarket 量化 / Claude Code 搭系统 / Learn in public, Build in public），外部链接一律去评论区跟推 |
 
 ---
 

--- a/docs/SHORTS_PIPELINE.md
+++ b/docs/SHORTS_PIPELINE.md
@@ -6,13 +6,15 @@
 Phase 1 of claude-video-kit's video format routing: vertical 9:16 short
 videos (≤60s, big text, dense motion) for 抖音 / TikTok / 小红书 / B 站 Shorts.
 
-YouTube Shorts is **out of this delivery pack**. New flow: video first ships
-to X (Leo manual), then Claude re-publishes the local mp4 to YouTube via
-`~/.config/youtube/upload.py` with title/description authored at upload time.
+**YouTube 和 B 站走 API 直发，平行并列，不进网盘交付包**。视频在 X 定稿后：
+- YouTube: `~/.config/youtube/upload.py`（OAuth；title / description 在命令里手写）
+- B 站:    `~/.config/bilibili/upload.py <project>`（biliup CLI 底层；读 `distribute/bilibili/` metadata；默认 tid=231 科学科普）
+
+网盘交付包**只为抖音 / 小红书**生成（家人代发，封号风险高不做自动化）。
 
 ---
 
-## 端到端管线（6 步）
+## 端到端管线（7 步）
 
 ```
 1. 写 script.json   →  含 brand + slides (voice_text / caption_text 可选)
@@ -21,10 +23,15 @@ to X (Leo manual), then Claude re-publishes the local mp4 to YouTube via
 4. align.py         →  workspace/captions.json (按 voice_text 一字不差对齐)
 5. render + mux     →  remotion render + ffmpeg +faststart
 6. 分发包 + 网盘     →  ⚠️ 定稿后强制流程，禁跳
-                        ① 3 平台 metadata 全部按定稿文稿同步刷新（B站/抖音/小红书；YouTube 走 X→upload.py 链路另发）
+                        ① 3 平台 metadata 全部按定稿文稿同步刷新（B站/抖音/小红书）
                         ② cover.png 重抓（frame ≥1.0s）
                         ③ subtitles-zh.srt 从最新 captions.json 重生
-                        ④ 整个 distribute/ 文件夹形式上传百度网盘（禁打包 zip）
+                        ④ 抖音 / 小红书 distribute 文件夹上传百度网盘（家人代发；禁打包 zip）
+                           B 站的 distribute/bilibili/ 不进网盘，作 Step 7 的 metadata 来源
+7. 平台发布          →  Leo 各一行命令，YouTube + B 站平行 API 直发
+                        - YouTube: `python3 ~/.config/youtube/upload.py`
+                        - B 站:    `python3 ~/.config/bilibili/upload.py <project>`
+                        抖音 / 小红书继续 Step 6 网盘 → 家人代发
 ```
 
 每步标准在下文。
@@ -334,7 +341,7 @@ preset: "long"    →  1920×1080 / 30fps / fontScale=0.9 / max 7200s（Phase 3 
 3. 通过 → Step 6 分发包 + Step 7 各平台发布
 4. 不通过 → 回上游修（script.json / voice_text / slide）→ 重跑
 
-**禁止**：render 完直接调 youtube/upload.py 或 push X / TG / B 站。
+**禁止**：render 完直接调 youtube/upload.py、bilibili/upload.py 或 push X / TG。
 **违规事件**：2026-04-30 第一次跑通 #10 视频，render 后直接调 youtube unlisted upload，被 Leo 当场叫停（output 0 byte 没真传）。
 
 ---
@@ -367,7 +374,20 @@ preset: "long"    →  1920×1080 / 30fps / fontScale=0.9 / max 7200s（Phase 3 
 
 每个平台在 `distribute/<platform>/` 下有：title / description-or-正文 / tags。**最终视频文稿改了任何措辞，所有 3 个平台的 description 必须同步更新**。
 
-> YouTube 不在交付包内。视频在 X 定稿后，Claude 用 `~/.config/youtube/upload.py` 直发，title / description 在上传命令里手写。
+> **YouTube 和 B 站都走 API 直发（Step 7）**，不进网盘。
+>
+> 网盘交付**只为抖音 / 小红书**（家人代发）。B 站的 `distribute/bilibili/` 文件作为 `~/.config/bilibili/upload.py` 的 metadata 来源使用，本身不上传网盘。
+
+**双文件名约定**（B 站 metadata，build-distribute-pack.mjs 输出 + Leo 手写覆盖）：
+
+| 用途 | 自动生成（stub） | Leo 手写终稿（优先级更高） |
+|---|---|---|
+| 标题 | `01-title.txt` | `01-标题.txt` |
+| 描述 | `02-description.txt` | `02-描述.txt` |
+| 章节 | `03-chapters.txt` | `03-章节.txt` |
+| 标签 | `04-tags.txt` | `04-标签.txt` |
+
+`upload.py` 优先读中文版（手写更精致），fallback 英文版。
 
 红线：
 - ❌ 平台 description 引用了视频删掉的钩子（如 "95%" strawman）
@@ -405,6 +425,47 @@ BaiduPCS-Go share set /claude-video-kit/<slug>/
 ```
 
 输出 share URL 给 Leo。
+
+---
+
+## Step 7 · 平台发布（YouTube + B 站 API 直发，平行并列 · 2026-04-30 立）
+
+Step 6 完成后，Leo 各跑一行命令完成 YouTube 和 B 站发布。两个平台**平行并列**，没有顺序依赖。
+
+### 7.1 YouTube 直发
+
+```bash
+python3 ~/.config/youtube/upload.py
+# title / description 在命令里输入
+```
+
+依赖：`~/.config/youtube/{client_secret.json, token.json}`（OAuth 已配，token 自动 refresh）
+
+### 7.2 B 站直发
+
+```bash
+python3 ~/.config/bilibili/upload.py <project_dir>
+# 默认 tid=231 科学科普, copyright=1 自制
+# 自动读 distribute/bilibili/ 下 title / desc / tags / chapters
+```
+
+依赖：
+- `~/.local/bin/biliup` （v0.2.4 binary，aarch64-macos）
+- `~/.config/bilibili/cookies.json` （扫码登录生成；过期跑 `cd ~/.config/bilibili/ && ~/.local/bin/biliup login` 重扫）
+
+可选参数：
+- `--tid <int>` — 换分区（231=科学科普 / 171=科技数码 / 完整列表查 `https://api.bilibili.com/x/web-interface/zone`）
+- `--cover <path>` — 自定义封面（默认查 `cover.png` / `distribute/bilibili/cover.png`，找不到 B 站自动截首帧）
+- `--copyright 2 --source <url>` — 转载视频
+- `--dry-run` — 只打印参数不上传（首次跑务必 dry-run 验证）
+
+成功输出：BV 号 + aid + 上传线路 + 进入 B 站审核（一般 30min 内过审）。
+
+**首次实测样例**（2026-04-30）：karpathy-9-11-shorts → BV1iw9aBSEpk，14MB / 38s / 0.40 MB/s（bda2 线路）。
+
+### 7.3 抖音 / 小红书
+
+继续走 Step 6 网盘交付链 → 家人手动发布。**不做自动化**：抖音/小红书风控对脚本/cookie 自动化敏感，账号有积累的情况下封号代价 > 自动化收益。
 
 ---
 

--- a/examples/karpathy-9-11-shorts/_build_srt.py
+++ b/examples/karpathy-9-11-shorts/_build_srt.py
@@ -1,0 +1,30 @@
+"""Build SRT from captions.json + metadata.json (frame-relative → global)."""
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+META = json.loads((ROOT / "metadata.json").read_text())
+CAPS = json.loads((ROOT / "workspace/captions.json").read_text())
+FPS = META["fps"]
+
+def fmt(frame: int) -> str:
+    s = frame / FPS
+    h = int(s // 3600)
+    m = int((s % 3600) // 60)
+    sec = s - h * 3600 - m * 60
+    return f"{h:02d}:{m:02d}:{sec:06.3f}".replace(".", ",")
+
+offset_frames = 0
+lines = []
+idx_global = 0
+for i, slide in enumerate(META["slides"]):
+    key = f"{i:02d}"
+    for cap in CAPS.get(key, []):
+        idx_global += 1
+        gf_from = offset_frames + cap["from"]
+        gf_to = offset_frames + cap["to"]
+        lines.append(f"{idx_global}\n{fmt(gf_from)} --> {fmt(gf_to)}\n{cap['text']}\n")
+    offset_frames += slide["durationInFrames"]
+
+(ROOT / "distribute/subtitles-zh.srt").write_text("\n".join(lines))
+print(f"→ distribute/subtitles-zh.srt ({idx_global} cues)")

--- a/examples/karpathy-9-11-shorts/script.json
+++ b/examples/karpathy-9-11-shorts/script.json
@@ -1,0 +1,110 @@
+{
+  "title": "ChatGPT 在小学题翻车的真正原因 (shorts)",
+  "preset": "shorts",
+  "fps": 30,
+  "brand": {
+    "handle": "@runes_leo",
+    "url": "leolabs.me",
+    "logoSrc": "leo-labs-logo.jpeg",
+    "accentColor": "#f59e0b"
+  },
+  "_note": "Karpathy 'Deep Dive into LLMs' 解读系列 #1 · 单点反常识 + tokenizer 切词演示 · 跨圈钩子 · 评论区放原视频 https://www.youtube.com/watch?v=7xTGNNLPyMI",
+  "slides": [
+    {
+      "type": "cover",
+      "title": "ChatGPT 能解 PhD 物理\n却在这道小学题翻车",
+      "subtitle": "原因不在数学",
+      "eyebrow": "Karpathy 新视频解读",
+      "accentColor": "#f59e0b",
+      "voice_text": "ChatGPT 能解博士级别的物理题，却会在一道小学数学题上稳定翻车。",
+      "caption_text": "ChatGPT 能解 PhD 物理 · 却在这道小学题翻车"
+    },
+    {
+      "type": "numberHero",
+      "heroValue": "9.11 > 9.9 ?",
+      "heroLabel": "ChatGPT 答：9.11 大",
+      "heroBadge": "翻车现场",
+      "heroAccentColor": "#ef4444",
+      "voice_text": "我问它，9.11 比 9.9 哪个大？它说 9.11 大。这个答案，错。",
+      "caption_text": "9.11 > 9.9? · ChatGPT 答 9.11 大 · 错"
+    },
+    {
+      "type": "text",
+      "textMode": "hero",
+      "textReveal": "spring",
+      "text": "Karpathy 三小时新视频\n专门讲了这个 bug",
+      "accentColor": "#a78bfa",
+      "voice_text": "Andrej Karpathy 最近发了一个三小时讲 LLM 的视频，里面专门讲了这个 bug 为什么修不掉。",
+      "caption_text": "Karpathy 三小时讲 LLM 新视频 · 专门讲了这个 bug"
+    },
+    {
+      "type": "numberHero",
+      "heroValue": "不是数学差",
+      "heroLabel": "是看不见这串字",
+      "heroBadge": "原因",
+      "heroAccentColor": "#10b981",
+      "voice_text": "原因不是模型数学差。是它根本看不见 9.11 和 9.9 这两串字符。",
+      "caption_text": "不是数学差 · 是看不见这串字"
+    },
+    {
+      "type": "text",
+      "textMode": "hero",
+      "text": "模型读到的不是数字\n是 token",
+      "accentColor": "#3b82f6",
+      "voice_text": "模型读到的不是数字本身，是 token，也就是被切碎的字符片段。",
+      "caption_text": "模型读到的不是数字 · 是 token (字符片段)"
+    },
+    {
+      "type": "numberHero",
+      "heroValue": "[ 9 ｜ . ｜ 11 ]",
+      "heroLabel": "9.11 在模型眼里",
+      "heroBadge": "切片",
+      "heroAccentColor": "#3b82f6",
+      "voice_text": "9.11 在它眼里，被切成三段：9、点、11。",
+      "caption_text": "9.11 → [ 9 · . · 11 ]"
+    },
+    {
+      "type": "numberHero",
+      "heroValue": "[ 9 ｜ . ｜ 9 ]",
+      "heroLabel": "9.9 在模型眼里",
+      "heroBadge": "切片",
+      "heroAccentColor": "#3b82f6",
+      "voice_text": "9.9 被切成的也是三段：9、点、然后又是 9。",
+      "caption_text": "9.9 → [ 9 · . · 9 ]"
+    },
+    {
+      "type": "numberHero",
+      "heroValue": "11 > 9",
+      "heroLabel": "模型对比的是这两个数",
+      "heroBadge": "结论",
+      "heroAccentColor": "#ec4899",
+      "voice_text": "在它的世界里，11 比 9 大，所以它说 9.11 比 9.9 大。",
+      "caption_text": "在 token 空间里 · 11 大于 9"
+    },
+    {
+      "type": "text",
+      "textMode": "hero",
+      "text": "数 strawberry 几个 r\n字母拼接、计数\n全是同一种翻车",
+      "accentColor": "#f59e0b",
+      "voice_text": "你问它草莓 strawberry 这个词里有几个字母 r，它经常自信答错。同一种翻车。",
+      "caption_text": "数 strawberry 几个 r · 也常答错 · 同一种翻车"
+    },
+    {
+      "type": "cover",
+      "title": "用 AI 的真本事\n是知道它哪里看不见",
+      "subtitle": "不是写 prompt 多花哨",
+      "accentColor": "#f59e0b",
+      "voice_text": "用大模型的真本事，不是 prompt 写得多花哨。是脑子里有一份它会翻车的清单。",
+      "caption_text": "用 AI 的真本事 · 知道它哪里看不见"
+    },
+    {
+      "type": "cover",
+      "title": "@runes_leo · leolabs.me",
+      "subtitle": "AI × Crypto 独立构建者",
+      "eyebrow": "Learn in public, Build in public",
+      "accentColor": "#f59e0b",
+      "voice_text": "我是 Leo，做 AI 和加密的独立构建者。在 Polymarket 做量化，用 Claude Code 搭数据和自动化系统。更多在 leolabs.me，下次见。",
+      "caption_text": "Polymarket 量化 · Claude Code 搭系统 · leolabs.me"
+    }
+  ]
+}

--- a/scripts/align.py
+++ b/scripts/align.py
@@ -72,17 +72,23 @@ def wav_duration(wav_path: Path) -> float:
 
 def split_by_punct(text: str):
     import re
-    # Split on Chinese/English sentence punctuation but keep non-empty pieces.
-    parts = re.split(r"[，,。.！!？?；;]", text)
-    return [p.strip() for p in parts if p.strip()]
+    # Split on Chinese/English sentence punctuation, but DON'T split on:
+    #   - "." between digits (e.g. 9.11, 9.9 — domain decimals)
+    #   - "." between letters (e.g. leolabs.me, U.S. — domain dots, abbrevs)
+    # Without this guard, captions from "9.11 比 9.9 大" would render
+    # "9", "11 比 9", "9 大" with the decimal point lost.
+    pattern = r"[，,。！!？?；;]|(?<![\w\d])\.|\.(?![\w\d])"
+    parts = re.split(pattern, text)
+    return [p.strip() for p in parts if p and p.strip()]
 
 
 def captions_from_script(text: str, wav_path: Path, fps: int):
-    """Build captions from script's caption_text (or voice_text).
+    """Build captions from script's voice_text using char-ratio split.
 
-    Splits on punctuation, allocates each chunk a slice of wav duration
-    proportional to its character count. 100% accurate text + natural
-    breaks at punctuation, no Whisper guessing.
+    Legacy fallback. Splits on punctuation, allocates each chunk a slice
+    of wav duration proportional to its character count. Inaccurate when
+    voice_text has mixed Chinese + English / proper nouns (different read
+    speeds). Use captions_from_script_whisper_aligned() for production.
     """
     pieces = split_by_punct(text)
     if not pieces:
@@ -103,6 +109,83 @@ def captions_from_script(text: str, wav_path: Path, fps: int):
     return captions
 
 
+def captions_from_script_whisper_aligned(text: str, wav_path: Path, fps: int, model, t2s=None):
+    """Hybrid: whisper word timestamps for accurate timing + voice_text for caption text.
+
+    Whisper transcribes the wav with word_timestamps=True. We then map
+    voice_text character positions to whisper character positions (linear
+    stretch) to read out the actual time at each punctuation boundary.
+    This handles uneven read speed (Chinese vs English vs proper nouns)
+    that pure char-ratio cannot.
+
+    Falls back to char-ratio if whisper produces no words.
+    """
+    segments, _ = model.transcribe(
+        str(wav_path),
+        word_timestamps=True,
+        vad_filter=False,
+        language="zh",
+        initial_prompt="以下是简体中文的内容。",
+    )
+    # Build per-character end-time map from whisper words.
+    whisper_char_times = []  # list of cumulative end times, one per char
+    for seg in segments:
+        for word in seg.words or []:
+            wt = word.word.strip()
+            if t2s:
+                wt = t2s.convert(wt)
+            n = len(wt)
+            if n == 0:
+                continue
+            t_start = word.start
+            t_end = word.end
+            # Distribute word duration uniformly across its chars
+            for k in range(n):
+                ch_end = t_start + (t_end - t_start) * (k + 1) / n
+                whisper_char_times.append(ch_end)
+
+    if not whisper_char_times:
+        # Whisper failed; fall back
+        return captions_from_script(text, wav_path, fps)
+
+    pieces = split_by_punct(text)
+    if not pieces:
+        return []
+
+    voice_total = sum(len(p) for p in pieces) or 1
+    whisper_total = len(whisper_char_times)
+    duration = wav_duration(wav_path)
+
+    captions = []
+    voice_cursor = 0
+    for piece in pieces:
+        start_voice = voice_cursor
+        end_voice = voice_cursor + len(piece)
+
+        # Map voice char position to whisper char position
+        start_whisper = int(start_voice * whisper_total / voice_total)
+        end_whisper = int(end_voice * whisper_total / voice_total)
+        # Clamp
+        start_whisper = max(0, min(start_whisper, whisper_total - 1))
+        end_whisper = max(0, min(end_whisper, whisper_total - 1))
+
+        start_time = 0.0 if start_whisper == 0 else whisper_char_times[start_whisper - 1]
+        end_time = whisper_char_times[end_whisper]
+
+        # Clamp to wav duration
+        end_time = min(end_time, duration)
+        start_time = min(start_time, end_time)
+
+        captions.append({
+            "from": int(start_time * fps),
+            "to": int(end_time * fps),
+            "text": piece,
+        })
+        voice_cursor = end_voice
+
+    return captions
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("project")
@@ -110,6 +193,8 @@ def main() -> int:
     ap.add_argument("--model", default="base")
     ap.add_argument("--force-whisper", action="store_true",
                     help="Ignore script caption_text/voice_text, transcribe via Whisper")
+    ap.add_argument("--legacy-char-ratio", action="store_true",
+                    help="Use old char-ratio split (no whisper). Inaccurate with mixed CN/EN.")
     args = ap.parse_args()
 
     project = Path(args.project)
@@ -138,11 +223,9 @@ def main() -> int:
             slide = script["slides"][slide_idx]
             caption_source = slide.get("voice_text") or slide.get("caption_text")
 
-        if caption_source:
-            print(f"aligning {wav.name} from script ({len(caption_source)} chars)...")
-            result[idx] = captions_from_script(caption_source, wav, args.fps)
-        else:
-            # Fall back to Whisper
+        # Lazy-load whisper unless using legacy char-ratio mode
+        def _ensure_whisper():
+            nonlocal whisper_model, t2s
             if whisper_model is None:
                 from faster_whisper import WhisperModel
                 try:
@@ -152,8 +235,19 @@ def main() -> int:
                     print("opencc not installed; captions may contain traditional chars")
                     t2s = None
                 whisper_model = WhisperModel(args.model, device="auto", compute_type="int8")
-            print(f"aligning {wav.name} via whisper...")
-            result[idx] = transcribe(wav, whisper_model, args.fps, t2s=t2s)
+            return whisper_model, t2s
+
+        if caption_source and args.legacy_char_ratio:
+            print(f"aligning {wav.name} from script (legacy char-ratio, {len(caption_source)} chars)...")
+            result[idx] = captions_from_script(caption_source, wav, args.fps)
+        elif caption_source:
+            wm, ts = _ensure_whisper()
+            print(f"aligning {wav.name} via whisper-timed voice_text ({len(caption_source)} chars)...")
+            result[idx] = captions_from_script_whisper_aligned(caption_source, wav, args.fps, wm, t2s=ts)
+        else:
+            wm, ts = _ensure_whisper()
+            print(f"aligning {wav.name} via whisper transcription...")
+            result[idx] = transcribe(wav, wm, args.fps, t2s=ts)
 
     out = workspace / "captions.json"
     out.write_text(json.dumps(result, ensure_ascii=False, indent=2))

--- a/scripts/modal_tts_batch.py
+++ b/scripts/modal_tts_batch.py
@@ -22,6 +22,33 @@ import argparse
 
 app = modal.App("claude-video-kit-tts")
 
+
+# Pronunciation pre-processing.
+#
+# IndexTTS2 (even on Modal A10G fp16) sometimes mispronounces English letter
+# initialisms and domain names embedded in Chinese context. Substitute with
+# Chinese phonetic equivalents BEFORE TTS so audio comes out right; the
+# original voice_text in script.json stays unchanged so align/caption still
+# render the original spelling.
+#
+# Add new entries when you hit a new mispronunciation. Order matters:
+# longer / more-specific keys first to avoid partial-match conflicts.
+PRONUNCIATION_FIXES = [
+    # 域名 "." 不加空格会被当中文句号读错节奏（Leo 验收 OK）
+    ("leolabs.me", "leolabs点 me"),
+    # 注: "AI" 历史撞过 IndexTTS2 不稳定读成 "A1"/"I1"。直译"诶艾"或
+    # 替换"人工智能"都不自然（Leo 反馈"英文不能这样读"）。当前策略 =
+    # 多次跑 + _good/<NN>.wav 锁定念对的版本（wav cache 复用机制），
+    # 不靠预处理替换。voice_text 给足上下文 hint 即可。
+]
+
+
+def apply_pronunciation_fixes(text: str) -> str:
+    for k, v in PRONUNCIATION_FIXES:
+        text = text.replace(k, v)
+    return text
+
+
 image = (
     modal.Image.debian_slim(python_version="3.10")
     .apt_install("git", "ffmpeg", "libsndfile1", "build-essential")
@@ -115,16 +142,45 @@ def main(project: str = "examples/ai-resume-bias-truth-shorts"):
         raise SystemExit(f"missing voice ref {VOICE_REF}")
 
     data = json.loads(SCRIPT.read_text())
+
+    # _good/ wav cache reuse mechanism.
+    #
+    # IndexTTS2 is non-deterministic (sampling temperature). Same voice_text
+    # may pronounce English words right one run and wrong another. Workflow:
+    #   1. Run modal_tts → listen
+    #   2. For slides that pronounced correctly: cp workspace/NN.wav workspace/_good/NN.wav
+    #   3. Re-run modal_tts → automatically skips slides with _good/NN.wav, only
+    #      regenerates the failed ones
+    #   4. Repeat until all marked good. From then on, modal cost = 0 for
+    #      unchanged voice_text.
+    GOOD_DIR = WORKSPACE / "_good"
+    GOOD_DIR.mkdir(exist_ok=True)
+
     entries = {}
+    reused = 0
     for i, slide in enumerate(data.get("slides", [])):
         text = slide.get("voice_text") or slide.get("text") or slide.get("title")
         if not text:
             continue
-        entries[str(i)] = text
-    if not entries:
-        raise SystemExit("no voice_text in script.json")
 
-    print(f">> submitting {len(entries)} slides to Modal A10G...")
+        good_wav = GOOD_DIR / f"{i:02d}.wav"
+        if good_wav.exists():
+            target = WORKSPACE / f"{i:02d}.wav"
+            target.write_bytes(good_wav.read_bytes())
+            print(f"  slide {i}: reusing _good/{i:02d}.wav (skip modal)", flush=True)
+            reused += 1
+            continue
+
+        fixed = apply_pronunciation_fixes(text)
+        if fixed != text:
+            print(f"  slide {i}: pronunciation fixed → {fixed[:60]}...", flush=True)
+        entries[str(i)] = fixed
+
+    if not entries:
+        print(f">> all {reused} slides reused from _good/, skipping modal entirely")
+        return
+
+    print(f">> submitting {len(entries)} slides to Modal A10G ({reused} reused from _good/)...")
     t0 = time.time()
     results = infer_batch.remote(VOICE_REF.read_bytes(), entries)
     dt = time.time() - t0
@@ -133,3 +189,4 @@ def main(project: str = "examples/ai-resume-bias-truth-shorts"):
         out = WORKSPACE / f"{int(num):02d}.wav"
         out.write_bytes(wav_bytes)
     print(f">> {len(results)} wavs saved to {WORKSPACE} in {dt/60:.1f}min")
+    print(f">> tip: cp workspace/NN.wav workspace/_good/NN.wav to lock pronunciations you like")


### PR DESCRIPTION
## Summary

Two related commits on the karpathy-9-11-shorts feature branch:

- **707d447** — Pipeline hardening + Karpathy #1 reference example
  - Step 1 §结尾 slide P0 模板（Leo 品牌签名 cover）
  - Step 5.5 审核 stop 门（render 完不许直接发）
  - 视觉素材 / CTA 决策树
  - examples/karpathy-9-11-shorts/（11 slides + SRT builder）
  - align.py / modal_tts_batch.py 改进

- **97b0cbc** — Step 7 platform publish (YouTube + Bilibili parallel)
  - 端到端管线 6 → 7 步
  - Step 6 网盘交付剩抖音/小红书；YouTube + B 站升级到平行 Step 7 API 直发
  - B 站从 4 平台分发包砍出来（distribute/bilibili/ 留作 metadata 来源，不进网盘）
  - 双文件名 fallback：`01-标题.txt` 优先，`01-title.txt` fallback
  - biliup CLI v0.2.4 + cookies / 默认 tid=231 / dry-run / cover / 转载文档化
  - Step 5.5 禁令对称扩到 bilibili/upload.py
  - 首次实测样例 karpathy-9-11-shorts → BV1iw9aBSEpk (14MB/38s/bda2)

## Test plan

- [x] `python3 ~/.config/bilibili/upload.py <project> --dry-run` 调用链 OK
- [x] 真实上传 karpathy → BV1iw9aBSEpk 进 B 站审核
- [x] biliup renew 验证 cookies 兼容
- [ ] (后续) 下一条新视频走 Step 7 端到端跑通

🤖 Generated with [Claude Code](https://claude.com/claude-code)