### PR TITLE
fix(align): 跳过 QA 步骤留下的备份 wav

### DIFF
--- a/scripts/align.py
+++ b/scripts/align.py
@@ -17,6 +17,7 @@ Writes:
 Usage:
     python scripts/align.py <project_dir> [--fps 30] [--model base]
 """
+import re
 import argparse
 import json
 from pathlib import Path
@@ -318,6 +319,10 @@ def main() -> int:
 
     for wav in wavs:
         idx = wav.stem  # "00", "01", ...
+        # 只认 NN.wav。各 QA 步骤会留下 NN.before-phantom-head.wav 这类备份，
+        # 它们不是音轨，撞上 int() 会让整条渲染在最后一步崩掉（2026-08-10 实例）。
+        if not re.fullmatch(r"\d+", idx):
+            continue
         slide_idx = int(idx)
         caption_source = None
         if script and slide_idx < len(script.get("slides", [])):


### PR DESCRIPTION
## 问题

各 QA 步骤会在 `workspace/` 下留备份文件：

```
00.before-phantom-head.wav
00.before-sentence-stitch.wav
00.before-stitch-leadin-cut.wav
```

`align.py` 用文件名前缀当 slide 索引：

```python
idx = wav.stem          # 期望 "00", "01", ...
slide_idx = int(idx)    # int("00.before-sentence-stitch") → ValueError
```

于是整条渲染在**最后一步**崩掉，而此前所有阶段（TTS、逐镜 QA、lint、逐镜审批）都已通过。

## 修法

只认 `NN.wav`，其余跳过：

```python
if not re.fullmatch(r"\d+", idx):
    continue
```

## 为什么值得修

这类失败的代价不对称：前面 40 分钟的 QA 全跑完了才崩，而错误本身跟内容无关，
纯粹是把「工具留下的中间产物」当成了「正式输入」。

跳过而不是报错，是因为备份文件本身是有用的（回滚素材），不该强制清理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)