### PR TITLE
视频管线：修八个静默失败

### DIFF
--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -14,6 +14,8 @@ import { TableSlide, TableCell } from "./compositions/TableSlide";
 import { FormulaSlide, FormulaGroup } from "./compositions/FormulaSlide";
 import { TransitionSlide } from "./compositions/TransitionSlide";
 import { NumberHero } from "./compositions/NumberHero";
+import { ScreenshotSlide, Highlight } from "./compositions/ScreenshotSlide";
+import { FlowDiagram, FlowNode, FlowEdge } from "./compositions/FlowDiagram";
 import { CaptionsLayer, CaptionPosition } from "./compositions/CaptionsLayer";
 import { BrandConfig } from "./compositions/BrandedSlideLayout";
 import { Preset, resolvePreset } from "./presets";
@@ -44,7 +46,9 @@ type SlideMeta = {
     | "table"
     | "formula"
     | "transition"
-    | "numberHero";
+    | "numberHero"
+    | "screenshot"
+    | "flow";
   durationInFrames: number;
   audio?: string;
   captions?: Array<{ from: number; to: number; text: string }>;
@@ -96,6 +100,19 @@ type SlideMeta = {
   formulaCaption?: string;
   formulaPrefix?: string;
 
+  // flow — 机制示意图，节点/连线逐步演出
+  nodes?: FlowNode[];
+  edges?: FlowEdge[];
+  verdict?: string;
+  verdictAt?: number;
+  verdictColor?: "orange" | "green" | "blue" | "red";
+
+  // screenshot — 真实截图 + 动画高亮标注
+  src?: string;
+  highlights?: Highlight[];
+  caption?: string;
+  focus?: { x: number; y: number; w: number; h: number };
+
   // numberHero (shorts data-hook slide)
   heroValue?: string | number;
   heroLabel?: string;
@@ -108,6 +125,9 @@ type SlideMeta = {
   captionHighlight?: string[];
   captionPosition?: CaptionPosition;
   captionMaxCharsPerLine?: number;
+
+  /** screenshot: 截图宽高比，高亮层据此贴合 contain 后的真实图片矩形 */
+  aspect?: number;
 };
 
 type Metadata = {
@@ -236,6 +256,34 @@ const Main: React.FC<Metadata> = (meta) => {
                 rows={slide.tableData.rows}
                 footer={slide.tableData.footer}
                 animateNumbers={slide.tableData.animateNumbers}
+              />
+            )}
+            {slide.type === "flow" && slide.nodes && (
+              <FlowDiagram
+                slideNumber={slideNumber}
+                totalSlides={total}
+                durationInFrames={slide.durationInFrames}
+                brand={meta.brand}
+                title={slide.title}
+                nodes={slide.nodes}
+                edges={slide.edges}
+                verdict={slide.verdict}
+                verdictAt={slide.verdictAt}
+                verdictColor={slide.verdictColor}
+              />
+            )}
+            {slide.type === "screenshot" && slide.src && (
+              <ScreenshotSlide
+                slideNumber={slideNumber}
+                totalSlides={total}
+                durationInFrames={slide.durationInFrames}
+                brand={meta.brand}
+                title={slide.title}
+                src={slide.src}
+                highlights={slide.highlights}
+                caption={slide.caption}
+                focus={slide.focus}
+                aspect={slide.aspect}
               />
             )}
             {slide.type === "formula" && slide.formulaGroups && (

--- a/remotion/src/compositions/CaptionsLayer.tsx
+++ b/remotion/src/compositions/CaptionsLayer.tsx
@@ -134,17 +134,22 @@ export const CaptionsLayer: React.FC<CaptionsLayerProps> = ({
   position = "bottom",
   highlight,
   accentColor = "#f59e0b",
-  maxCharsPerLine = 10,
+  maxCharsPerLine,
 }) => {
   const frame = useCurrentFrame();
-  const { fps } = useVideoConfig();
+  const { fps, width } = useVideoConfig();
 
   if (!captions || captions.length === 0) return null;
 
   const active = captions.find((c) => frame >= c.from && frame < c.to);
   if (!active) return null;
 
-  const lines = wrapText(active.text, maxCharsPerLine);
+  // 2026-08-01：默认值原本写死 10 —— 那是竖版 1080 宽的数。横版 1920 沿用同一个值，
+  // 每句都被切成三行小短条（「同时还得在传统券商那 / 边备一笔现金和股票库 / 存去对冲」），
+  // 既断在词中间，又因为行数多而压住画面里的结论条和截图。
+  // 每字约占 88px 宽（含字距），按画布宽度算才对。
+  const autoMax = Math.max(10, Math.round(width / 88));
+  const lines = wrapText(active.text, maxCharsPerLine ?? autoMax);
   const captionFont = 38 * fontScale;
 
   // Spring entrance per-caption: starts at this caption's `from` frame.

--- a/remotion/src/compositions/CoverSlide.tsx
+++ b/remotion/src/compositions/CoverSlide.tsx
@@ -137,6 +137,9 @@ export const CoverSlide: React.FC<CoverSlideProps> = ({
             lineHeight: 1.1,
             fontFamily: "'Inter', -apple-system, 'PingFang SC', sans-serif",
             textShadow: `0 0 80px ${accentColor}55`,
+            // 2026-08-01：title 里的 \n 此前被当空格，中文标题在错的地方折行
+            //（「你手里的美股代币 现在能直 / 接当保证金」）。作者写了换行就该断在那。
+            whiteSpace: "pre-line",
           }}
         >
           {title}

--- a/remotion/src/compositions/FlowDiagram.tsx
+++ b/remotion/src/compositions/FlowDiagram.tsx
@@ -1,0 +1,296 @@
+import React from "react";
+import {
+  AbsoluteFill,
+  interpolate,
+  spring,
+  useCurrentFrame,
+  useVideoConfig,
+} from "remotion";
+import { BrandedSlideLayout, BrandConfig } from "./BrandedSlideLayout";
+
+/**
+ * FlowDiagram — 资金 / 流程流动示意图，逐步演出
+ *
+ * 为什么存在（Leo 2026-08-01）：
+ *   「画面必须得有用……不能是底下有字幕，上面再显示一遍一样的大文字」
+ *   讲机制的分镜没有现成截图，必须用画面把机制演出来。
+ *   典型场景：一笔钱分成两份被锁进两个盒子（双重抵押）→ 两盒合一（解法）。
+ *
+ * 设计：
+ *   nodes  = 盒子（可标 locked 显示锁定态）
+ *   edges  = 从 source 流向 target 的资金线，带流动小球
+ *   steps  = 每一步在第几秒出现，按口播节奏逐个点亮
+ */
+
+export interface FlowNode {
+  id: string;
+  label: string;
+  /** 归一化位置 0–1（画布内） */
+  x: number;
+  y: number;
+  w?: number;
+  sub?: string;
+  color?: "orange" | "green" | "blue" | "gray";
+  /** 出现时机（秒） */
+  at?: number;
+  /** 显示「已锁定」徽记 */
+  locked?: boolean;
+  /** 徽记出现时机（秒），默认 at+0.8 */
+  lockAt?: number;
+}
+
+export interface FlowEdge {
+  from: string;
+  to: string;
+  label?: string;
+  at?: number;
+  color?: "orange" | "green" | "blue" | "gray";
+  /** 是否在线上跑流动小球 */
+  animate?: boolean;
+}
+
+export interface FlowDiagramProps {
+  slideNumber: number;
+  totalSlides: number;
+  durationInFrames?: number;
+  brand?: BrandConfig;
+  title?: string;
+  nodes: FlowNode[];
+  edges?: FlowEdge[];
+  /** 底部结论，最后出现 */
+  verdict?: string;
+  verdictAt?: number;
+  verdictColor?: "orange" | "green" | "blue" | "red";
+}
+
+const C = {
+  orange: "#e8822a",
+  green: "#4ade80",
+  blue: "#60a5fa",
+  gray: "#6b7280",
+  red: "#f87171",
+} as const;
+
+export const FlowDiagram: React.FC<FlowDiagramProps> = ({
+  slideNumber,
+  totalSlides,
+  durationInFrames = 240,
+  brand,
+  title,
+  nodes,
+  edges = [],
+  verdict,
+  verdictAt,
+  verdictColor = "orange",
+}) => {
+  const frame = useCurrentFrame();
+  const { fps, width, height } = useVideoConfig();
+
+  // 画布区（标题下方、结论上方）
+  // CAPTION_SAFE 同 ScreenshotSlide：字幕层固定 bottom:220px，两行会顶到 y≈0.70。
+  // verdict 条也必须让在字幕之上，否则结论和字幕叠字。
+  const CAPTION_SAFE = 290;
+  const top = title ? height * 0.18 : height * 0.09;
+  const bottom = CAPTION_SAFE + (verdict ? 150 : 0);
+  const areaH = height - top - bottom;
+  const areaW = width * 0.86;
+  const areaX = width * 0.07;
+
+  const px = (nx: number) => areaX + nx * areaW;
+  const py = (ny: number) => top + ny * areaH;
+
+  const nodeById = Object.fromEntries(nodes.map((n) => [n.id, n]));
+
+  return (
+    <BrandedSlideLayout
+      slideNumber={slideNumber}
+      totalSlides={totalSlides}
+      durationInFrames={durationInFrames}
+      brand={brand}
+    >
+      {title ? (
+        <div
+          style={{
+            position: "absolute",
+            left: "6%",
+            top: "7%",
+            fontSize: 54,
+            fontWeight: 700,
+            color: "#f9fafb",
+            letterSpacing: "-0.01em",
+            opacity: interpolate(frame, [0, 10], [0, 1], { extrapolateRight: "clamp" }),
+            transform: `translateY(${interpolate(frame, [0, 14], [16, 0], {
+              extrapolateRight: "clamp",
+            })}px)`,
+          }}
+        >
+          {title}
+        </div>
+      ) : null}
+
+      <AbsoluteFill>
+        {/* 连线层 */}
+        <svg
+          width={width}
+          height={height}
+          style={{ position: "absolute", left: 0, top: 0 }}
+        >
+          {edges.map((e, i) => {
+            const a = nodeById[e.from];
+            const b = nodeById[e.to];
+            if (!a || !b) return null;
+            const at = (e.at ?? 1.2 + i * 0.5) * fps;
+            const p = interpolate(frame - at, [0, 22], [0, 1], {
+              extrapolateLeft: "clamp",
+              extrapolateRight: "clamp",
+            });
+            if (frame < at) return null;
+            const col = C[e.color ?? "orange"];
+            const x1 = px(a.x);
+            const y1 = py(a.y);
+            const x2 = px(b.x);
+            const y2 = py(b.y);
+            const cx = x1 + (x2 - x1) * p;
+            const cy = y1 + (y2 - y1) * p;
+
+            // 流动小球位置（沿已画出的线循环）
+            const t = ((frame - at) % (fps * 1.6)) / (fps * 1.6);
+            const bx = x1 + (cx - x1) * t;
+            const by = y1 + (cy - y1) * t;
+
+            return (
+              <g key={i}>
+                <line
+                  x1={x1}
+                  y1={y1}
+                  x2={cx}
+                  y2={cy}
+                  stroke={col}
+                  strokeWidth={5}
+                  strokeLinecap="round"
+                  opacity={0.55}
+                />
+                {e.animate !== false && p > 0.98 ? (
+                  <circle cx={bx} cy={by} r={11} fill={col} opacity={0.95} />
+                ) : null}
+                {e.label && p > 0.6 ? (
+                  <text
+                    x={(x1 + x2) / 2}
+                    y={(y1 + y2) / 2 - 18}
+                    fill="#c9c9d1"
+                    fontSize={30}
+                    textAnchor="middle"
+                    opacity={interpolate(p, [0.6, 1], [0, 1])}
+                  >
+                    {e.label}
+                  </text>
+                ) : null}
+              </g>
+            );
+          })}
+        </svg>
+
+        {/* 节点层 */}
+        {nodes.map((n, i) => {
+          const at = (n.at ?? 0.4 + i * 0.6) * fps;
+          const s = spring({
+            frame: frame - at,
+            fps,
+            config: { damping: 15, stiffness: 130 },
+          });
+          if (frame < at) return null;
+          const col = C[n.color ?? "gray"];
+          const w = (n.w ?? 0.24) * areaW;
+          const lockAt = (n.lockAt ?? (n.at ?? 0.4 + i * 0.6) + 1.0) * fps;
+          const lockS = spring({
+            frame: frame - lockAt,
+            fps,
+            config: { damping: 14, stiffness: 160 },
+          });
+          return (
+            <div
+              key={n.id}
+              style={{
+                position: "absolute",
+                left: px(n.x) - w / 2,
+                top: py(n.y) - 62,
+                width: w,
+                padding: "22px 26px",
+                background: "rgba(255,255,255,0.045)",
+                border: `3px solid ${col}`,
+                borderRadius: 18,
+                textAlign: "center",
+                opacity: s,
+                transform: `scale(${0.9 + 0.1 * s})`,
+              }}
+            >
+              <div style={{ fontSize: 38, fontWeight: 700, color: "#fff" }}>
+                {n.label}
+              </div>
+              {n.sub ? (
+                <div style={{ fontSize: 26, color: "#a1a1aa", marginTop: 8 }}>
+                  {n.sub}
+                </div>
+              ) : null}
+              {n.locked && frame >= lockAt ? (
+                <div
+                  style={{
+                    position: "absolute",
+                    right: -14,
+                    top: -18,
+                    background: C.red,
+                    color: "#0a0a0c",
+                    fontSize: 24,
+                    fontWeight: 700,
+                    padding: "6px 14px",
+                    borderRadius: 999,
+                    opacity: lockS,
+                    transform: `scale(${0.7 + 0.3 * lockS}) rotate(${
+                      (1 - lockS) * -12
+                    }deg)`,
+                  }}
+                >
+                  已锁定
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+
+        {/* 结论条 */}
+        {verdict ? (
+          (() => {
+            const at = (verdictAt ?? 4.5) * fps;
+            const s = spring({
+              frame: frame - at,
+              fps,
+              config: { damping: 16, stiffness: 120 },
+            });
+            if (frame < at) return null;
+            return (
+              <div
+                style={{
+                  position: "absolute",
+                  left: areaX,
+                  bottom: CAPTION_SAFE + 30,
+                  width: areaW,
+                  padding: "24px 32px",
+                  background: `${C[verdictColor]}18`,
+                  borderLeft: `8px solid ${C[verdictColor]}`,
+                  borderRadius: "0 16px 16px 0",
+                  fontSize: 44,
+                  fontWeight: 700,
+                  color: "#fff",
+                  opacity: s,
+                  transform: `translateX(${(1 - s) * -26}px)`,
+                }}
+              >
+                {verdict}
+              </div>
+            );
+          })()
+        ) : null}
+      </AbsoluteFill>
+    </BrandedSlideLayout>
+  );
+};

--- a/remotion/src/compositions/ScreenshotSlide.tsx
+++ b/remotion/src/compositions/ScreenshotSlide.tsx
@@ -1,0 +1,334 @@
+import React from "react";
+import {
+  AbsoluteFill,
+  Img,
+  staticFile,
+  interpolate,
+  spring,
+  useCurrentFrame,
+  useVideoConfig,
+} from "remotion";
+import { BrandedSlideLayout, BrandConfig } from "./BrandedSlideLayout";
+
+/**
+ * ScreenshotSlide — 真实截图 + 动画高亮标注
+ *
+ * 为什么存在（Leo 2026-08-01）：
+ *   「画面必须得有用。不能是底下已经有了字幕，上面分镜里又显示一遍
+ *     跟字幕一模一样的大文字，这有什么用？」
+ *   文字类 slide 只是把口播排版了一遍，零信息增量。观众需要看到
+ *   「证据长什么样」——官方文档的那一行、面板上的那个数字。
+ *
+ * 与配图路由 SSOT 一致：真实截图 + 中文标注 > 精致卡片。
+ *
+ * ⚠️ 素材与坐标的两条铁律（2026-08-01 踩了两版才总结出来）：
+ *   1. 截图必须预裁到「显示框比例」再用。显示框 = (width-10%) : (height*0.71)
+ *      ≈ 2.25:1。原图若是 4:3，objectFit:contain 会留左右白边，
+ *      归一化坐标全部失准。
+ *   2. highlights 坐标必须【裁完之后直接量裁后的图】，
+ *      不要用「原图坐标 - 裁剪偏移」推算 —— 原图坐标常来自缩放显示的目测，
+ *      误差会被裁剪放大（实测偏了 0.1 = 40px，高亮框整体浮到表头上方）。
+ *
+ * 动画设计：
+ *   - 截图整体缓慢推近（Ken Burns），避免死图
+ *   - 高亮框按 `at` 逐个弹入（spring），配合口播节奏点出重点
+ *   - 可选 focus：镜头推向指定区域，做「拉近看细节」
+ */
+
+export interface Highlight {
+  /** 相对截图的归一化坐标 0–1 */
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  /** 标注文案，显示在框旁边 */
+  label?: string;
+  /** 出现时机：相对本 slide 的秒数 */
+  at?: number;
+  color?: "orange" | "green" | "blue" | "red";
+  /**
+   * 标签相对高亮框的位置。不给则按 x 自动（右半区放下方，否则右侧）。
+   *
+   * 2026-08-01：自动规则试了三版都不够用——同一行有两个框时左右都没空位（费率面板），
+   * 表格行距小时下方会压住下一行数字（DefiLlama 那张五个标签全盖住了下一行）。
+   * 「哪里有空」是这张图的事实，组件猜不出来，交给写分镜的人指定。
+   */
+  labelSide?: "right" | "left" | "below" | "above";
+}
+
+export interface ScreenshotSlideProps {
+  slideNumber: number;
+  totalSlides: number;
+  durationInFrames?: number;
+  brand?: BrandConfig;
+
+  title?: string;
+  /** 截图文件名，相对 public-dir */
+  src: string;
+  highlights?: Highlight[];
+  /** 底部一行说明（数据来源等） */
+  caption?: string;
+  /** 镜头最终推向的区域（归一化），不给则整图缓慢推近 */
+  focus?: { x: number; y: number; w: number; h: number };
+  /**
+   * 截图的宽高比（宽/高）。给了之后，高亮层会贴着 contain 之后的**实际图片矩形**定位，
+   * 截图不必再预裁到显示框比例。
+   *
+   * 2026-08-01：原设计要求作者把截图裁成显示框比例（≈2.25:1），
+   * 结果只要有人调了标题高度或字幕安全区，显示框比例一变，
+   * 所有已标好的高亮坐标就集体错位——而且不报错，只是框偏在一边。
+   * 把「图片实际画在哪」交给组件算，比让每个作者记住一个会变的数字可靠。
+   */
+  aspect?: number;
+}
+
+const COLORS = {
+  orange: "#e8822a",
+  green: "#4ade80",
+  blue: "#60a5fa",
+  red: "#f87171",
+} as const;
+
+export const ScreenshotSlide: React.FC<ScreenshotSlideProps> = ({
+  slideNumber,
+  totalSlides,
+  durationInFrames = 150,
+  brand,
+  title,
+  src,
+  highlights = [],
+  caption,
+  focus,
+  aspect,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps, width, height } = useVideoConfig();
+
+  // 截图区：标题占顶部，说明占底部
+  //
+  // ⚠️ CAPTION_SAFE（2026-08-01 Leo 抽查发现）：字幕层固定在 bottom:220px，
+  // 两行中文会顶到 y≈0.70。此前截图区画到 height*0.88，字幕直接压在图上
+  // （抵扣率那张的「系统只算九百美元保证金」正好盖住第三行 10% 高亮框）。
+  // 画面组件必须为字幕留出这块，不能靠"大概不会撞上"。
+  const CAPTION_SAFE = 290;
+  const padX = width * 0.05;
+  const top = title ? height * 0.15 : height * 0.07;
+  const bottom = CAPTION_SAFE + (caption ? 60 : 0);
+  const boxW = width - padX * 2;
+  const boxH = height - top - bottom;
+
+  // objectFit:contain 之后，图片实际占的矩形（相对 box 左上角）。
+  // 没给 aspect 就退回旧行为（假设图片正好填满 box）。
+  const boxAR = boxW / boxH;
+  const fitW = aspect ? (aspect > boxAR ? boxW : boxH * aspect) : boxW;
+  const fitH = aspect ? (aspect > boxAR ? boxW / aspect : boxH) : boxH;
+  const offX = (boxW - fitW) / 2;
+  const offY = (boxH - fitH) / 2;
+
+  // 整体镜头：无 focus 时缓慢推近；有 focus 时从全景推向该区域
+  const t = interpolate(frame, [0, durationInFrames], [0, 1], {
+    extrapolateRight: "clamp",
+  });
+  const eased = 1 - Math.pow(1 - t, 2.2);
+
+  // 缩放原点用像素（相对 box），这样图片层和高亮层能落在同一个坐标系上。
+  // focus 是相对**图片**的归一化坐标，先换算到图片矩形内，再加上 contain 的偏移。
+  let scale = 1 + 0.06 * eased;
+  let originPxX = boxW / 2;
+  let originPxY = boxH / 2;
+  if (focus) {
+    const targetScale = Math.min(2.4, 1 / Math.max(focus.w, focus.h));
+    scale = 1 + (targetScale - 1) * eased;
+    originPxX = offX + (focus.x + focus.w / 2) * fitW;
+    originPxY = offY + (focus.y + focus.h / 2) * fitH;
+  }
+  const imgOrigin = `${originPxX}px ${originPxY}px`;
+  // 高亮层元素本身就是图片矩形，所以原点要减掉 contain 偏移
+  const hlOrigin = `${originPxX - offX}px ${originPxY - offY}px`;
+
+  const fadeIn = interpolate(frame, [0, 12], [0, 1], {
+    extrapolateRight: "clamp",
+  });
+
+  return (
+    <BrandedSlideLayout
+      slideNumber={slideNumber}
+      totalSlides={totalSlides}
+      durationInFrames={durationInFrames}
+      brand={brand}
+    >
+      {title ? (
+        <div
+          style={{
+            position: "absolute",
+            left: "5%",
+            top: "7%",
+            fontSize: 52,
+            fontWeight: 700,
+            color: "#f9fafb",
+            letterSpacing: "-0.01em",
+            opacity: interpolate(frame, [0, 10], [0, 1], { extrapolateRight: "clamp" }),
+            transform: `translateY(${interpolate(frame, [0, 14], [14, 0], { extrapolateRight: "clamp" })}px)`,
+          }}
+        >
+          {title}
+        </div>
+      ) : null}
+      <AbsoluteFill>
+        <div
+          style={{
+            position: "absolute",
+            left: padX,
+            top,
+            width: boxW,
+            height: boxH,
+            borderRadius: 18,
+            overflow: "hidden",
+            border: "1px solid rgba(255,255,255,0.10)",
+            opacity: fadeIn,
+            background: "#0a0a0c",
+          }}
+        >
+          <div
+            style={{
+              width: "100%",
+              height: "100%",
+              transform: `scale(${scale})`,
+              transformOrigin: imgOrigin,
+            }}
+          >
+            <Img
+              src={staticFile(src)}
+              style={{
+                width: "100%",
+                height: "100%",
+                objectFit: "contain",
+                display: "block",
+              }}
+            />
+
+          </div>
+        </div>
+
+        <div
+          style={{
+            position: "absolute",
+            left: padX,
+            top,
+            width: boxW,
+            height: boxH,
+            overflow: "hidden",
+            pointerEvents: "none",
+          }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              // 高亮层贴的是 contain 之后的图片矩形，不是整个显示框——
+              // 归一化坐标因此始终相对图片本身，显示框比例怎么变都不会错位。
+              left: offX,
+              top: offY,
+              width: fitW,
+              height: fitH,
+              transform: `scale(${scale})`,
+              transformOrigin: hlOrigin,
+            }}
+          >
+            {highlights.map((h, i) => {
+              const at = (h.at ?? 0.6 + i * 0.9) * fps;
+              const sp = spring({
+                frame: frame - at,
+                fps,
+                config: { damping: 16, stiffness: 140 },
+              });
+              if (frame < at) return null;
+              const c = COLORS[h.color ?? "orange"];
+              return (
+                <React.Fragment key={i}>
+                  <div
+                    style={{
+                      position: "absolute",
+                      left: `${h.x * 100}%`,
+                      top: `${h.y * 100}%`,
+                      width: `${h.w * 100}%`,
+                      height: `${h.h * 100}%`,
+                      border: `${3 / scale}px solid ${c}`,
+                      borderRadius: 8 / scale,
+                      boxShadow: `0 0 0 ${5 / scale}px ${c}26`,
+                      transform: `scale(${0.94 + 0.06 * sp})`,
+                      opacity: sp,
+                    }}
+                  />
+                  {h.label ? (
+                    <div
+                      style={{
+                        position: "absolute",
+                        ...(() => {
+                          const side =
+                            h.labelSide ?? (h.x + h.w > 0.62 ? "below" : "right");
+                          if (side === "left")
+                            return {
+                              right: `${(1 - h.x) * 100}%`,
+                              top: `${h.y * 100}%`,
+                              marginRight: 14 / scale,
+                            };
+                          if (side === "below")
+                            return {
+                              left: `${h.x * 100}%`,
+                              top: `${(h.y + h.h) * 100}%`,
+                              marginTop: 10 / scale,
+                            };
+                          if (side === "above")
+                            return {
+                              left: `${h.x * 100}%`,
+                              bottom: `${(1 - h.y) * 100}%`,
+                              marginBottom: 10 / scale,
+                            };
+                          return {
+                            left: `${(h.x + h.w) * 100}%`,
+                            top: `${h.y * 100}%`,
+                            marginLeft: 14 / scale,
+                          };
+                        })(),
+                        padding: `${8 / scale}px ${14 / scale}px`,
+                        background: "rgba(10,10,12,0.94)",
+                        border: `${2 / scale}px solid ${c}`,
+                        borderRadius: 10 / scale,
+                        color: "#fff",
+                        fontSize: 26 / scale,
+                        fontWeight: 600,
+                        whiteSpace: "nowrap",
+                        opacity: sp,
+                        transform: `translateX(${(1 - sp) * -12}px)`,
+                      }}
+                    >
+                      {h.label}
+                    </div>
+                  ) : null}
+                </React.Fragment>
+              );
+            })}
+          </div>
+        </div>
+
+        {caption ? (
+          <div
+            style={{
+              position: "absolute",
+              left: padX,
+              bottom: CAPTION_SAFE + 8,
+              width: boxW,
+              color: "#8a8a94",
+              fontSize: 24,
+              fontFamily: "ui-monospace, Menlo, monospace",
+              letterSpacing: "0.04em",
+              opacity: fadeIn,
+            }}
+          >
+            {caption}
+          </div>
+        ) : null}
+      </AbsoluteFill>
+    </BrandedSlideLayout>
+  );
+};

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -31,9 +31,27 @@ case "$ALIGN_MODE" in
     ;;
 esac
 
-echo "▶ [1/4] TTS (backend: ${TTS_BACKEND:-fish})"
 PYTHON="${PYTHON:-python3}"
-case "${TTS_BACKEND:-fish}" in
+
+# 2026-08-01：后端必须能从 script.json 的 _meta.tts_backend 读。
+# 事故：Ondo 那期用 cosyvoice 克隆音色录好后，跑了一次 render.sh，
+# 默认 fish 后端把 15.wav 直接覆盖成了别人的声音（27.9s → 22.8s）。
+# 「项目该用哪个后端」是项目的属性，不该只活在某次调用的环境变量里。
+BACKEND="${TTS_BACKEND:-$("$PYTHON" - "$PROJECT" <<'PY'
+import json,sys,pathlib
+try:
+    d=json.loads((pathlib.Path(sys.argv[1])/"script.json").read_text())
+    print(d.get("_meta",{}).get("tts_backend","") or "")
+except Exception:
+    print("")
+PY
+)}"
+BACKEND="${BACKEND:-fish}"
+echo "▶ [1/4] TTS (backend: $BACKEND)"
+case "$BACKEND" in
+  cosyvoice)
+    "$PYTHON" "$KIT_ROOT/scripts/tts_cosyvoice.py" "$PROJECT"
+    ;;
   indextts2)
     "$PYTHON" "$KIT_ROOT/scripts/tts_indextts2.py" "$PROJECT"
     ;;

--- a/scripts/tts.py
+++ b/scripts/tts.py
@@ -80,7 +80,11 @@ def local_fallback(text: str, out_path: Path) -> None:
 def extract_text(slide: dict) -> str:
     if "voice_text" in slide:
         return slide["voice_text"]
-    if slide.get("type") == "cover":
+    # 2026-08-01：cover 分支必须让位给显式 text（同 tts_cosyvoice.py / tts_indextts2.py）。
+    # 这份是 align.py 直接 import 的那一份——即使项目用 cosyvoice 后端配音，
+    # 字幕仍走这里。Ondo 那期音频念对了、字幕却是封面标题，根因就在这。
+    # 同一个规则散落在四个文件里，改三个不够。
+    if slide.get("type") == "cover" and not (slide.get("text") or "").strip():
         parts = [slide.get("title", ""), slide.get("subtitle", "")]
         return " ".join(p for p in parts if p)
     if slide.get("type") == "code":

--- a/scripts/tts_cosyvoice.py
+++ b/scripts/tts_cosyvoice.py
@@ -15,7 +15,8 @@ Env:
   COSYVOICE_MODEL        默认 "cosyvoice-v3.5-plus"
   COSYVOICE_VOICE_ID     必填；预制音色（默认 voice）或 voice clone 创建后的 id
   COSYVOICE_FORCE        =1 强制重生成
-  COSYVOICE_SPEED        默认 1.08（与 IndexTTS2 对齐）
+  COSYVOICE_SPEED        默认 1.0。⛔ 禁止倍速——Leo 规则：加速产生爆破音。
+                         （2026-08-01 由 1.08 改为 1.0；此前默认值导致多条视频被无意加速）
   COSYVOICE_FORMAT       "wav" / "mp3" 默认 wav
   VOICE_RULES_PATH       optional JSON preprocessing rules; defaults to config sample
 
@@ -39,14 +40,31 @@ DEFAULT_VOICE_RULES_PATH = Path(__file__).resolve().parents[1] / "config" / "voi
 VOICE_RULES_PATH = Path(os.environ.get("VOICE_RULES_PATH", str(DEFAULT_VOICE_RULES_PATH))).expanduser()
 
 
-def load_voice_rules() -> dict:
-    if not VOICE_RULES_PATH.exists():
-        return {}
-    try:
-        return json.loads(VOICE_RULES_PATH.read_text())
-    except Exception as e:
-        print(f"[warn] failed to load voice rules: {e}", flush=True)
-        return {}
+def load_voice_rules(project=None) -> dict:
+    """优先级：环境变量 VOICE_RULES_PATH > <project>/voice-rules.json > kit 默认 sample。
+
+    2026-08-01：此前只认默认 sample，项目目录里的 voice-rules.json **从来不被读**。
+    于是 Ondo 那期在项目里写好的 SPYon / QQQon / USDC 规则形同虚设，
+    SPYon 被念成「斯派」、QQQon 念成「QQ-KONE」——而且 7-31 给 USDT 加的规则
+    也是加在项目文件里，同样一直没生效（当时以为修好了）。
+    「配置放在了工具不看的地方」不会报错，只会安静地念错。
+    """
+    candidates = []
+    if os.environ.get("VOICE_RULES_PATH"):
+        candidates.append(Path(os.environ["VOICE_RULES_PATH"]).expanduser())
+    if project is not None:
+        candidates.append(Path(project) / "voice-rules.json")
+    candidates.append(DEFAULT_VOICE_RULES_PATH)
+
+    for p in candidates:
+        if p.exists():
+            try:
+                rules = json.loads(p.read_text())
+                print(f"[voice rules] source: {p}", flush=True)
+                return rules
+            except Exception as e:
+                print(f"[warn] failed to load voice rules {p}: {e}", flush=True)
+    return {}
 
 
 def preprocess_voice_text(text: str, rules: dict) -> str:
@@ -85,7 +103,12 @@ def extract_text(slide: dict) -> str:
         return slide["voice_text"]
     if "narration" in slide:
         return slide["narration"]
-    if slide.get("type") == "cover":
+    # 2026-08-01：cover 分支必须让位给显式 text。
+    # 事故：Ondo 那期封面与片尾写了 title/subtitle 做画面，text 里另有口播稿，
+    # 结果 TTS 念的是标题（「做市商的资金被锁了两次 这才是股权永续真正的瓶颈」），
+    # 整段开场白和结语的配音直接丢失，而画面看起来完全正常。
+    # 有 text 就以 text 为准；title 只是没写口播时的兜底。
+    if slide.get("type") == "cover" and not (slide.get("text") or "").strip():
         parts = [slide.get("title", ""), slide.get("subtitle", "")]
         return " ".join(p for p in parts if p)
     return slide.get("text", "")
@@ -168,13 +191,34 @@ def main() -> int:
 
     # 2026-05-15 smoke test：v3.5-plus 预制音色名跟文档对不上（可能只支持 voice clone），
     # 先用 cosyvoice-v2 + longxiaochun_v2 跑通管线。最终生产用 Leo voice clone（target_model 自己指定）。
+    # 2026-08-01 修 bug：此前 _meta 注入写在这段之后，导致 script.json 的
+    # cosyvoice_speed / model / voice 永远不生效（读的是环境变量或默认值）。
+    # 这就是「语速改了又变回 1.18」的根因。必须先注入再读。
+    script_preload = json.loads(script_path.read_text())
+    _m = script_preload.get("_meta", {}) if isinstance(script_preload, dict) else {}
+    for _env, _key in (("COSYVOICE_MODEL", "cosyvoice_model"),
+                       ("COSYVOICE_VOICE_ID", "cosyvoice_voice"),
+                       ("COSYVOICE_SPEED", "cosyvoice_speed")):
+        if not os.environ.get(_env) and _m.get(_key) is not None:
+            os.environ[_env] = str(_m[_key])
+
     model = os.environ.get("COSYVOICE_MODEL", "cosyvoice-v2")
     voice = os.environ.get("COSYVOICE_VOICE_ID", "longxiaochun_v2")
     fmt = os.environ.get("COSYVOICE_FORMAT", "wav")
     try:
-        speed = float(os.environ.get("COSYVOICE_SPEED", "1.08"))
+        speed = float(os.environ.get("COSYVOICE_SPEED", "1.0"))  # ⛔ 不要改回 1.08，倍速有爆破音
     except ValueError:
         speed = 1.0
+    # fail closed，不是 warning。2026-08-01：此处原本只打印警告然后照跑，
+    # 于是 ~/.zshenv 里遗留的 COSYVOICE_SPEED=1.18 连续污染了两期视频而没人拦住。
+    # 「警告不是守卫」——要拦就得真的退出。
+    if speed != 1.0:
+        print(f"⛔ speed={speed}x —— Leo 规则：TTS 一律 1.0，倍速产生爆破音。已中止。\n"
+              f"   来源排查顺序：环境变量 COSYVOICE_SPEED（当前 shell / ~/.zshenv）"
+              f" > script.json 的 _meta.cosyvoice_speed > 本脚本默认值。\n"
+              f"   确需倍速请显式 TTS_ALLOW_SPEEDUP=1 重跑。", flush=True)
+        if os.environ.get("TTS_ALLOW_SPEEDUP") != "1":
+            sys.exit(3)
 
     try:
         import dashscope  # noqa: F401
@@ -185,12 +229,12 @@ def main() -> int:
 
     print(f"CosyVoice config: model={model} voice={voice} speed={speed}x format={fmt}", flush=True)
 
-    script = json.loads(script_path.read_text())
+    script = script_preload
     slides = script.get("slides", script) if isinstance(script, dict) else script
     workspace = project / "workspace"
     workspace.mkdir(exist_ok=True)
 
-    voice_rules = load_voice_rules()
+    voice_rules = load_voice_rules(project)
     if voice_rules:
         print(
             f"[voice rules] loaded {len(voice_rules.get('tokens', {}))} tokens + "

--- a/scripts/tts_indextts2.py
+++ b/scripts/tts_indextts2.py
@@ -35,14 +35,24 @@ DEFAULT_VOICE_RULES_PATH = Path(__file__).resolve().parents[1] / "config" / "voi
 VOICE_RULES_PATH = Path(os.environ.get("VOICE_RULES_PATH", str(DEFAULT_VOICE_RULES_PATH))).expanduser()
 
 
-def load_voice_rules() -> dict:
-    if not VOICE_RULES_PATH.exists():
-        return {}
-    try:
-        return json.loads(VOICE_RULES_PATH.read_text())
-    except Exception as e:
-        print(f"[warn] failed to load voice rules: {e}", flush=True)
-        return {}
+def load_voice_rules(project=None) -> dict:
+    """优先级：VOICE_RULES_PATH > <project>/voice-rules.json > kit 默认 sample。
+    同 tts_cosyvoice.py，2026-08-01 修：项目级规则此前从不被读取。"""
+    candidates = []
+    if os.environ.get("VOICE_RULES_PATH"):
+        candidates.append(Path(os.environ["VOICE_RULES_PATH"]).expanduser())
+    if project is not None:
+        candidates.append(Path(project) / "voice-rules.json")
+    candidates.append(DEFAULT_VOICE_RULES_PATH)
+    for p in candidates:
+        if p.exists():
+            try:
+                rules = json.loads(p.read_text())
+                print(f"[voice rules] source: {p}", flush=True)
+                return rules
+            except Exception as e:
+                print(f"[warn] failed to load voice rules {p}: {e}", flush=True)
+    return {}
 
 
 def preprocess_voice_text(text: str, rules: dict) -> str:
@@ -103,7 +113,8 @@ def extract_text(slide: dict) -> str:
         return slide["voice_text"]
     if "narration" in slide:
         return slide["narration"]
-    if slide.get("type") == "cover":
+    # 有 text 就以 text 为准（同 tts_cosyvoice.py，2026-08-01 修）
+    if slide.get("type") == "cover" and not (slide.get("text") or "").strip():
         parts = [slide.get("title", ""), slide.get("subtitle", "")]
         return " ".join(p for p in parts if p)
     return slide.get("text", "")
@@ -187,7 +198,7 @@ def main() -> int:
     workspace = project / "workspace"
     workspace.mkdir(exist_ok=True)
 
-    voice_rules = load_voice_rules()
+    voice_rules = load_voice_rules(project)
     if voice_rules:
         print(f"[voice rules] loaded {len(voice_rules.get('tokens', {}))} tokens + {len(voice_rules.get('letters', {}))} letters", flush=True)
 
@@ -230,7 +241,7 @@ def main() -> int:
 
         if out.exists():
             try:
-                speed = float(os.environ.get("INDEXTTS2_SPEED", "1.08"))
+                speed = float(os.environ.get("INDEXTTS2_SPEED", "1.0"))  # ⛔ 不要改回 1.08，倍速有爆破音
             except ValueError:
                 speed = 1.0
             if abs(speed - 1.0) > 0.01:


### PR DESCRIPTION
八个问题的共同点：**不报错、产物齐全、但做的不是那件事**。

| 现象 | 根因 | 修法 |
|---|---|---|
| 手工分镜配置被冲掉 | `render.sh` 无条件重建 metadata | 配置搬回 `script.json`（build-metadata 本就保留 slide 全字段）|
| 克隆音色被换成默认 | TTS 后端被默认值覆盖 | 从 `_meta.tts_backend` 读 |
| 读音修了却一直没生效 | `voice-rules.json` 项目级从不被读 | 加载优先级 env > project > 默认 |
| cover 分镜念标题不念口播稿 | 规则四份副本只改了三份 | 四处全修 |
| 横版字幕被切成三行短条 | `maxCharsPerLine` 默认 10 是竖版值 | 按画布宽度自适应 |
| 截图高亮坐标随版式失准 | 要求预裁，实际未裁 | 组件按 aspect 算 contain 后的真实矩形 |
| 高亮标签溢出压住内容 | 位置写死 | 加 `labelSide` 由作者指定 |
| cover title 的 `\n` 变空格 | 默认 `white-space` 折叠换行 | `whiteSpace: pre-line` |

新增两个组件：`FlowDiagram`（296 行）、`ScreenshotSlide`（334 行）。

## 为什么值得单独提

第 2 条（TTS 后端被默认值覆盖）在 2026-08-10 又以另一种形式出现过一次：
`daily.sh` 读 `_meta.tts_engine`，而 video-kit 这边读 `_meta.tts_backend` ——
同一个概念两个字段名，各有各的消费者，只设一个不会报错，
只会静默回退到默认引擎、撞上一个不存在的 venv 才崩。

这类失败没有一个会在测试里变红，只会在成片里被人眼看出来。

🤖 Generated with [Claude Code](https://claude.com/claude-code)