### PR TITLE
video pipeline: unify the chart layer, pin the voice backend, and make gates executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ npm ci --prefix remotion
 npx skills add runesleo/claude-video-kit --skill video-explainer
 npm run doctor -- --output /tmp/video-explainer-first-success
 npm run demo -- --output /tmp/video-explainer-first-success
+
+# npm scripts are thin wrappers — the underlying command works the same:
+#   node scripts/video-explainer.mjs demo --output /tmp/video-explainer-first-success
 ```
 
 The Skill orchestrates this local clone (it does not bundle Remotion). Demo creates a script-bound pass receipt, uses macOS `say` as an explicitly **demo-quality** voice, renders 1080×1920, and runs the shorts verifier — no API key, no upload. For real projects: `review` then `render`; `fix` / `block` / missing / stale receipts cannot start rendering. The six review checks are product-defined; pass/fail is judged by the reviewer — the tool enforces process, not truth.

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,6 +20,9 @@ npm ci --prefix remotion
 npx skills add runesleo/claude-video-kit --skill video-explainer
 npm run doctor -- --output /tmp/video-explainer-first-success
 npm run demo -- --output /tmp/video-explainer-first-success
+
+# npm script 只是薄封装，直接跑底层命令等价：
+#   node scripts/video-explainer.mjs demo --output /tmp/video-explainer-first-success
 ```
 
 Skill 编排的是本仓库本地渲染器（不打包 Remotion）。demo 会生成与脚本绑定的 pass 回执，用 macOS `say` 作**明确标注的 demo 音质**，输出 1080×1920 并跑 shorts 验收——无 API key、不上传。正式项目：先 `review` 再 `render`；`fix` / `block` / 缺失 / 过期都不能开渲。六个检查项是产品定的清单；过不过由 reviewer 判断——工具强制流程，不替你保证内容正确。

--- a/config/design-system.json
+++ b/config/design-system.json
@@ -1,0 +1,69 @@
+{
+  "$comment": [
+    "Canonical design system — the single source of truth for every video artifact,",
+    "regardless of length or format (shorts, mid-form, long-form).",
+    "",
+    "Why this file exists (2026-08-18): colors were defined in four places that had",
+    "drifted apart — a per-project DESIGN.md, remotion/src/ui-kit/theme.ts, hard-coded",
+    "hex in ContentSlide.tsx, and more hard-coded hex in scripts/gen_video_cover.py.",
+    "Two videos produced a week apart did not look like they came from the same",
+    "pipeline: one cover used #E67E22 on #0d1117, the frames used #ef4444 on #14171f,",
+    "and the project's own DESIGN.md specified #ee943e on #0c0f14. Nothing errored;",
+    "each piece was internally consistent and collectively incoherent.",
+    "",
+    "Values below are taken from the DESIGN.md of the deck whose look was approved,",
+    "so this is a codification of an existing decision, not a new one.",
+    "",
+    "Consumers MUST read from here rather than redeclaring hex:",
+    "  - remotion/src/ui-kit/theme.ts",
+    "  - remotion/src/compositions/*.tsx",
+    "  - scripts/gen_video_cover.py",
+    "A per-project DESIGN.md may only state deviations, and must say why."
+  ],
+
+  "canvas": {
+    "base": "#0c0f14",
+    "panel": "#141922",
+    "terminal": "#0f1218"
+  },
+
+  "text": {
+    "primary": "#eef2f7",
+    "muted": "#93a1b2",
+    "onAccent": "#0c0f14"
+  },
+
+  "semantic": {
+    "$comment": "accent is the only brand color. green/red carry meaning only — never decoration.",
+    "accent": "#ee943e",
+    "accentDeep": "#c9752c",
+    "verified": "#34c98f",
+    "invalid": "#ef6a6a"
+  },
+
+  "typography": {
+    "sans": ["PingFang SC", "Hiragino Sans GB", "sans-serif"],
+    "mono": ["IBM Plex Mono", "SFMono-Regular", "monospace"],
+    "titleSize": [72, 96],
+    "titleWeight": [800, 900],
+    "bodySize": [32, 42],
+    "bodyWeight": [350, 500],
+    "minDataLabelSize": 24,
+    "numericFeature": "tabular-nums",
+    "displayTracking": "-0.03em"
+  },
+
+  "layout": {
+    "width": 1920,
+    "height": 1080,
+    "safeAreaX": 120,
+    "safeAreaY": 90,
+    "captionBaselineFromBottom": 96
+  },
+
+  "cover": {
+    "$comment": "Cover art inherits canvas/semantic above. Persona is NOT global — see rule.",
+    "watermark": "@runes_leo · leolabs.me",
+    "personaRule": "Prediction-market content: no persona on the cover. Non-PM content: persona per the 2026-07-29 template."
+  }
+}

--- a/config/design-system.json
+++ b/config/design-system.json
@@ -20,19 +20,16 @@
     "  - scripts/gen_video_cover.py",
     "A per-project DESIGN.md may only state deviations, and must say why."
   ],
-
   "canvas": {
     "base": "#0c0f14",
     "panel": "#141922",
     "terminal": "#0f1218"
   },
-
   "text": {
     "primary": "#eef2f7",
     "muted": "#93a1b2",
     "onAccent": "#0c0f14"
   },
-
   "semantic": {
     "$comment": "accent is the only brand color. green/red carry meaning only — never decoration.",
     "accent": "#ee943e",
@@ -40,27 +37,46 @@
     "verified": "#34c98f",
     "invalid": "#ef6a6a"
   },
-
   "typography": {
-    "sans": ["PingFang SC", "Hiragino Sans GB", "sans-serif"],
-    "mono": ["IBM Plex Mono", "SFMono-Regular", "monospace"],
-    "titleSize": [72, 96],
-    "titleWeight": [800, 900],
-    "bodySize": [32, 42],
-    "bodyWeight": [350, 500],
+    "sans": [
+      "PingFang SC",
+      "Hiragino Sans GB",
+      "sans-serif"
+    ],
+    "mono": [
+      "IBM Plex Mono",
+      "SFMono-Regular",
+      "monospace"
+    ],
+    "titleSize": [
+      72,
+      96
+    ],
+    "titleWeight": [
+      800,
+      900
+    ],
+    "bodySize": [
+      32,
+      42
+    ],
+    "bodyWeight": [
+      350,
+      500
+    ],
     "minDataLabelSize": 24,
     "numericFeature": "tabular-nums",
     "displayTracking": "-0.03em"
   },
-
   "layout": {
     "width": 1920,
     "height": 1080,
     "safeAreaX": 120,
     "safeAreaY": 90,
-    "captionBaselineFromBottom": 96
+    "captionBaselineFromBottom": 96,
+    "brandBarHeight": 4,
+    "$brandBarNote": "顶部品牌渐变条的高度（1920 坐标系）。它横贯全宽，属设计的一部分，不是内容溢出 —— 逐帧安全区扫描必须先排除它，否则内容包围盒永远是满幅，2026-08-18 首次扫描即因此误报 169/263 帧。"
   },
-
   "cover": {
     "$comment": "Cover art inherits canvas/semantic above. Persona is NOT global — see rule.",
     "watermark": "@runes_leo · leolabs.me",

--- a/docs/LONGFORM_HYPERFRAMES_PIPELINE.md
+++ b/docs/LONGFORM_HYPERFRAMES_PIPELINE.md
@@ -73,7 +73,15 @@ The production long-form workflow auto-lints `long-form` projects and hard-fails
 | Aspect | 9:16 | 16:9 |
 | Engine | Remotion (`render.sh`) | HyperFrames (`npx hyperframes render`) |
 | Review | Studio / distribute | **slide-review.html** + approval JSON |
-| TTS | IndexTTS2 / Fish | **CosyVoice** (long segments) |
+| TTS | **CosyVoice** | **CosyVoice** |
+
+> **TTS backend is CosyVoice for both formats — this is not a per-format choice.**
+> When the channel publishes under a person's own name, the voice is part of that
+> identity; a stock voice makes it someone else talking, and the output sounds
+> perfectly fine, so no QA step will ever catch it. `render.sh` therefore defaults
+> to `cosyvoice`, `COSYVOICE_VOICE_ID` has no fallback to a preset voice, and an
+> unrecognised `TTS_BACKEND` exits non-zero instead of silently falling through to
+> a paid API. IndexTTS2 and Fish remain available for A/B comparison only.
 
 ---
 

--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -14,6 +14,9 @@ import { TableSlide, TableCell } from "./compositions/TableSlide";
 import { FormulaSlide, FormulaGroup } from "./compositions/FormulaSlide";
 import { TransitionSlide } from "./compositions/TransitionSlide";
 import { NumberHero } from "./compositions/NumberHero";
+import { BarCompare, BarItem } from "./compositions/charts/BarCompare";
+import { RangeSpan, SpanRow } from "./compositions/charts/RangeSpan";
+import { Scatter, Pt } from "./compositions/charts/Scatter";
 import { CaptionsLayer, CaptionPosition } from "./compositions/CaptionsLayer";
 import { BrandConfig } from "./compositions/BrandedSlideLayout";
 import { Preset, resolvePreset } from "./presets";
@@ -44,7 +47,10 @@ type SlideMeta = {
     | "table"
     | "formula"
     | "transition"
-    | "numberHero";
+    | "numberHero"
+    | "barCompare"
+    | "rangeSpan"
+    | "scatter";
   durationInFrames: number;
   audio?: string;
   captions?: Array<{ from: number; to: number; text: string }>;
@@ -90,6 +96,30 @@ type SlideMeta = {
     footer?: string;
     animateNumbers?: boolean;
   };
+
+  // charts (barCompare / rangeSpan / scatter) — data-visualisation slide types.
+  // Added 2026-08-18: the pipeline previously had no chart primitives at all,
+  // so decks whose gate demanded "~70% real data visualisation" could only ship
+  // text and text-laid-out tables. Declaring one of these types is now the
+  // supported way to satisfy that requirement.
+  chart?: {
+    // barCompare
+    items?: BarItem[];
+    unit?: string;
+    decimals?: number;
+    // rangeSpan
+    rows?: SpanRow[];
+    axisNote?: string;
+    // scatter
+    points?: Pt[];
+    synth?: { n: number; seed: number };
+    synthDisclosure?: string;
+    r?: number;
+    rLabel?: string;
+    xLabel?: string;
+    yLabel?: string;
+  };
+  footnote?: string;
 
   // formula
   formulaGroups?: FormulaGroup[];
@@ -258,6 +288,45 @@ const Main: React.FC<Metadata> = (meta) => {
                 brand={meta.brand}
                 title={slide.title ?? ""}
                 bullets={slide.bullets}
+              />
+            )}
+            {slide.type === "barCompare" && slide.chart?.items && (
+              <BarCompare
+                slideNumber={slideNumber}
+                totalSlides={total}
+                title={slide.title ?? ""}
+                subtitle={slide.subtitle}
+                footnote={slide.footnote}
+                items={slide.chart.items}
+                unit={slide.chart.unit}
+                decimals={slide.chart.decimals}
+              />
+            )}
+            {slide.type === "rangeSpan" && slide.chart?.rows && (
+              <RangeSpan
+                slideNumber={slideNumber}
+                totalSlides={total}
+                title={slide.title ?? ""}
+                subtitle={slide.subtitle}
+                footnote={slide.footnote}
+                rows={slide.chart.rows}
+                axisNote={slide.chart.axisNote}
+              />
+            )}
+            {slide.type === "scatter" && slide.chart?.r !== undefined && (
+              <Scatter
+                slideNumber={slideNumber}
+                totalSlides={total}
+                title={slide.title ?? ""}
+                subtitle={slide.subtitle}
+                footnote={slide.footnote}
+                points={slide.chart.points}
+                synth={slide.chart.synth}
+                synthDisclosure={slide.chart.synthDisclosure}
+                r={slide.chart.r}
+                rLabel={slide.chart.rLabel}
+                xLabel={slide.chart.xLabel}
+                yLabel={slide.chart.yLabel}
               />
             )}
             {slide.type === "numberHero" && slide.heroValue !== undefined && (

--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -17,6 +17,8 @@ import { NumberHero } from "./compositions/NumberHero";
 import { BarCompare, BarItem } from "./compositions/charts/BarCompare";
 import { RangeSpan, SpanRow } from "./compositions/charts/RangeSpan";
 import { Scatter, Pt } from "./compositions/charts/Scatter";
+import { DualColumn, DualGroup } from "./compositions/charts/DualColumn";
+import { ThresholdGrid, ThresholdCell } from "./compositions/charts/ThresholdGrid";
 import { CaptionsLayer, CaptionPosition } from "./compositions/CaptionsLayer";
 import { BrandConfig } from "./compositions/BrandedSlideLayout";
 import { Preset, resolvePreset } from "./presets";
@@ -50,7 +52,9 @@ type SlideMeta = {
     | "numberHero"
     | "barCompare"
     | "rangeSpan"
-    | "scatter";
+    | "scatter"
+    | "dualColumn"
+    | "thresholdGrid";
   durationInFrames: number;
   audio?: string;
   captions?: Array<{ from: number; to: number; text: string }>;
@@ -118,6 +122,14 @@ type SlideMeta = {
     rLabel?: string;
     xLabel?: string;
     yLabel?: string;
+    // dualColumn
+    groups?: DualGroup[];
+    leftLabel?: string;
+    rightLabel?: string;
+    ratioHeader?: string;
+    // thresholdGrid
+    cells?: ThresholdCell[];
+    verdict?: string;
   };
   footnote?: string;
 
@@ -327,6 +339,31 @@ const Main: React.FC<Metadata> = (meta) => {
                 rLabel={slide.chart.rLabel}
                 xLabel={slide.chart.xLabel}
                 yLabel={slide.chart.yLabel}
+              />
+            )}
+            {slide.type === "dualColumn" && slide.chart?.groups && (
+              <DualColumn
+                slideNumber={slideNumber}
+                totalSlides={total}
+                title={slide.title ?? ""}
+                subtitle={slide.subtitle}
+                footnote={slide.footnote}
+                groups={slide.chart.groups}
+                leftLabel={slide.chart.leftLabel ?? ""}
+                rightLabel={slide.chart.rightLabel ?? ""}
+                unit={slide.chart.unit}
+                ratioHeader={slide.chart.ratioHeader}
+              />
+            )}
+            {slide.type === "thresholdGrid" && slide.chart?.cells && (
+              <ThresholdGrid
+                slideNumber={slideNumber}
+                totalSlides={total}
+                title={slide.title ?? ""}
+                subtitle={slide.subtitle}
+                footnote={slide.footnote}
+                cells={slide.chart.cells}
+                verdict={slide.chart.verdict}
               />
             )}
             {slide.type === "numberHero" && slide.heroValue !== undefined && (

--- a/remotion/src/compositions/ContentSlide.tsx
+++ b/remotion/src/compositions/ContentSlide.tsx
@@ -72,27 +72,43 @@ export const ContentSlide: React.FC<ContentSlideProps> = ({
           marginBottom: hasBullets || body ? 50 : 60,
         }}
       >
-        {badge && (
-          <div
-            style={{
-              width: 80,
-              height: 80,
-              borderRadius: 16,
-              background: `linear-gradient(135deg, ${badgeGradient[0]}, ${badgeGradient[1]})`,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 36 * fontScale,
-              fontWeight: 800,
-              color: "#fff",
-              transform: `scale(${interpolate(badgeSpring, [0, 1], [0.5, 1])})`,
-              opacity: badgeSpring,
-              flexShrink: 0,
-            }}
-          >
-            {badge}
-          </div>
-        )}
+        {badge &&
+          (() => {
+            // badge 原本是写死的 80×80 方块 + fontSize 36，没有任何溢出保护。
+            // 超过约 2 个全角字就会溢出容器，压在标题和第一条 bullet 上 ——
+            // 而且渲染不报错，成片看起来"有画面"，QA 只有靠人眼才发现。
+            // 实测一条 5 badge 的片子里 3 个是长文本（日期、相关系数、一句提醒）。
+            // 所以短标签保持方块，长标签自动转 pill：宽度随内容走，永不换行，
+            // 字号按长度收敛，flexShrink:0 保证它不挤压右侧标题。
+            const chars = Array.from(badge).length;
+            const isPill = chars > 2;
+            const fs = (isPill ? (chars > 6 ? 24 : 28) : 36) * fontScale;
+            return (
+              <div
+                style={{
+                  ...(isPill
+                    ? { padding: "0 22px", minWidth: 80 }
+                    : { width: 80 }),
+                  height: 80,
+                  borderRadius: 16,
+                  background: `linear-gradient(135deg, ${badgeGradient[0]}, ${badgeGradient[1]})`,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: fs,
+                  fontWeight: 800,
+                  color: "#fff",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  transform: `scale(${interpolate(badgeSpring, [0, 1], [0.5, 1])})`,
+                  opacity: badgeSpring,
+                  flexShrink: 0,
+                }}
+              >
+                {badge}
+              </div>
+            );
+          })()}
         <div
           style={{
             fontSize: 52 * fontScale,

--- a/remotion/src/compositions/charts/BarCompare.tsx
+++ b/remotion/src/compositions/charts/BarCompare.tsx
@@ -1,0 +1,149 @@
+/**
+ * BarCompare — horizontal bar ranking with staggered growth and count-up labels.
+ *
+ * Use when the point is "these categories are not equal, and the order may be
+ * the opposite of what you expected". Bars grow in sequence so the eye lands on
+ * the ranking before the numbers finish counting.
+ *
+ * script.json:
+ *   {
+ *     "type": "barCompare",
+ *     "title": "① 品类：体育垫底，不是最好",
+ *     "subtitle": "rebateEv bps 中位 · n=1,004",
+ *     "chart": {
+ *       "unit": "bps",
+ *       "items": [
+ *         {"label": "Economics/Culture/Weather", "value": 175.2, "tone": "accent"},
+ *         {"label": "Crypto",  "value": 120.9},
+ *         {"label": "Finance/Politics/Tech", "value": 54.9},
+ *         {"label": "Sports",  "value": 51.2, "tone": "invalid", "note": "群内说法里的赢家"}
+ *       ]
+ *     },
+ *     "footnote": "2026-08-03 单次快照"
+ *   }
+ */
+import React from "react";
+import { interpolate } from "remotion";
+import { ChartFrame, DS, useCountUp, useGrow } from "./chartBase";
+
+export type BarItem = {
+  label: string;
+  value: number;
+  /** accent = the one to look at; invalid = the claim being refuted; default = neutral */
+  tone?: "accent" | "invalid" | "verified" | "neutral";
+  note?: string;
+};
+
+const toneColor = (tone?: BarItem["tone"]) =>
+  tone === "accent" ? DS.accent
+    : tone === "invalid" ? DS.invalid
+    : tone === "verified" ? DS.verified
+    : "#3a4454";
+
+/** One row. Kept as its own component so the hooks below are never called in a loop. */
+const BarRow: React.FC<{
+  item: BarItem;
+  max: number;
+  rowH: number;
+  delay: number;
+  unit: string;
+  decimals: number;
+}> = ({ item, max, rowH, delay, unit, decimals }) => {
+  const g = useGrow(delay);
+  const n = useCountUp(item.value, delay);
+  const w = interpolate(g, [0, 1], [0, (item.value / max) * 100]);
+  const c = toneColor(item.tone);
+  const emphasised = Boolean(item.tone && item.tone !== "neutral");
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 26, height: rowH }}>
+      <div
+        style={{
+          flex: "0 0 430px",
+          fontSize: 29,
+          textAlign: "right",
+          color: emphasised ? DS.text : DS.muted,
+          fontWeight: emphasised ? 700 : 400,
+        }}
+      >
+        {item.label}
+      </div>
+      {/* 右侧留白：数值+注释画在条形末端外侧，条形区必须留出空间，否则最长的一条会被画布右缘裁掉 */}
+      <div style={{ flex: 1, position: "relative", height: rowH * 0.58, marginRight: 300 }}>
+        <div style={{ position: "absolute", inset: 0, background: DS.panel, borderRadius: 10 }} />
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: `${w}%`,
+            background: c,
+            borderRadius: 10,
+            opacity: 0.92,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: `calc(${w}% + 22px)`,
+            top: "50%",
+            transform: "translateY(-50%)",
+            fontSize: 34,
+            fontWeight: 800,
+            fontFamily: DS.mono,
+            color: emphasised ? c : DS.muted,
+            whiteSpace: "nowrap",
+            opacity: g,
+          }}
+        >
+          {n.toFixed(decimals)}
+          {unit && <span style={{ fontSize: 22, marginLeft: 6 }}>{unit}</span>}
+          {item.note && (
+            <span style={{ fontSize: 22, color: DS.muted, marginLeft: 16, fontFamily: DS.sans }}>
+              {item.note}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const BarCompare: React.FC<{
+  title: string;
+  subtitle?: string;
+  footnote?: string;
+  slideNumber?: number;
+  totalSlides?: number;
+  items: BarItem[];
+  unit?: string;
+  decimals?: number;
+}> = ({ title, subtitle, footnote, slideNumber, totalSlides, items, unit = "", decimals = 1 }) => {
+  const max = Math.max(...items.map((i) => i.value), 1);
+  const rowH = Math.min(112, 560 / Math.max(items.length, 1));
+
+  return (
+    <ChartFrame
+      title={title}
+      subtitle={subtitle}
+      footnote={footnote}
+      slideNumber={slideNumber}
+      totalSlides={totalSlides}
+    >
+      <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: 18 }}>
+        {items.map((it, i) => (
+          <BarRow
+            key={it.label}
+            item={it}
+            max={max}
+            rowH={rowH}
+            delay={8 + i * 7}
+            unit={unit}
+            decimals={decimals}
+          />
+        ))}
+      </div>
+    </ChartFrame>
+  );
+};

--- a/remotion/src/compositions/charts/DualColumn.tsx
+++ b/remotion/src/compositions/charts/DualColumn.tsx
@@ -1,0 +1,190 @@
+/**
+ * DualColumn — paired bars per category, with the ratio as the punchline.
+ *
+ * Use when the claim is "A beats B across every category, no exceptions". Pairs
+ * grow together so the reader compares within a row first, then the ratio column
+ * lands and the repetition across rows does the arguing.
+ *
+ * script.json:
+ *   {
+ *     "type": "dualColumn",
+ *     "title": "② 冷热：热门碾压冷门，四类无一例外",
+ *     "chart": {
+ *       "leftLabel": "冷门半", "rightLabel": "热门半", "unit": "bps",
+ *       "groups": [
+ *         {"label": "Crypto", "left": 24.1, "right": 544.1, "ratio": "0.04×"},
+ *         {"label": "Sports", "left": 15.7, "right": 149.9, "ratio": "0.10×"}
+ *       ]
+ *     }
+ *   }
+ */
+import React from "react";
+import { interpolate } from "remotion";
+import { ChartFrame, DS, useCountUp, useGrow } from "./chartBase";
+
+export type DualGroup = {
+  label: string;
+  left: number;
+  right: number;
+  /** Pre-formatted ratio string — keeps rounding decisions in the data, not the view. */
+  ratio: string;
+};
+
+const Row: React.FC<{
+  group: DualGroup;
+  max: number;
+  delay: number;
+  rowH: number;
+}> = ({ group, max, delay, rowH }) => {
+  const gL = useGrow(delay);
+  const gR = useGrow(delay + 4);
+  const gRatio = useGrow(delay + 14);
+  const nL = useCountUp(group.left, delay);
+  const nR = useCountUp(group.right, delay + 4);
+
+  const barH = rowH * 0.34;
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 24, height: rowH }}>
+      <div style={{ flex: "0 0 330px", fontSize: 28, textAlign: "right", fontWeight: 600 }}>
+        {group.label}
+      </div>
+
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
+        {/* 冷门半 —— the side being refuted */}
+        <div style={{ position: "relative", height: barH }}>
+          <div
+            style={{
+              position: "absolute",
+              left: 0,
+              top: 0,
+              bottom: 0,
+              width: `${interpolate(gL, [0, 1], [0, (group.left / max) * 100])}%`,
+              background: DS.invalid,
+              borderRadius: 6,
+              opacity: 0.9,
+            }}
+          />
+          <div
+            style={{
+              position: "absolute",
+              left: `calc(${interpolate(gL, [0, 1], [0, (group.left / max) * 100])}% + 16px)`,
+              top: "50%",
+              transform: "translateY(-50%)",
+              fontSize: 24,
+              fontFamily: DS.mono,
+              color: DS.invalid,
+              whiteSpace: "nowrap",
+              opacity: gL,
+            }}
+          >
+            {nL.toFixed(1)}
+          </div>
+        </div>
+        {/* 热门半 */}
+        <div style={{ position: "relative", height: barH }}>
+          <div
+            style={{
+              position: "absolute",
+              left: 0,
+              top: 0,
+              bottom: 0,
+              width: `${interpolate(gR, [0, 1], [0, (group.right / max) * 100])}%`,
+              background: DS.accent,
+              borderRadius: 6,
+              opacity: 0.9,
+            }}
+          />
+          <div
+            style={{
+              position: "absolute",
+              left: `calc(${interpolate(gR, [0, 1], [0, (group.right / max) * 100])}% + 16px)`,
+              top: "50%",
+              transform: "translateY(-50%)",
+              fontSize: 24,
+              fontFamily: DS.mono,
+              color: DS.accent,
+              whiteSpace: "nowrap",
+              opacity: gR,
+            }}
+          >
+            {nR.toFixed(1)}
+          </div>
+        </div>
+      </div>
+
+      <div
+        style={{
+          flex: "0 0 150px",
+          fontSize: 40,
+          fontWeight: 900,
+          fontFamily: DS.mono,
+          color: DS.text,
+          textAlign: "right",
+          opacity: gRatio,
+          transform: `scale(${interpolate(gRatio, [0, 1], [0.75, 1])})`,
+        }}
+      >
+        {group.ratio}
+      </div>
+    </div>
+  );
+};
+
+export const DualColumn: React.FC<{
+  title: string;
+  subtitle?: string;
+  footnote?: string;
+  slideNumber?: number;
+  totalSlides?: number;
+  groups: DualGroup[];
+  leftLabel: string;
+  rightLabel: string;
+  unit?: string;
+  ratioHeader?: string;
+}> = ({
+  title,
+  subtitle,
+  footnote,
+  slideNumber,
+  totalSlides,
+  groups,
+  leftLabel,
+  rightLabel,
+  unit = "",
+  ratioHeader = "冷/热",
+}) => {
+  const max = Math.max(...groups.flatMap((g) => [g.left, g.right]), 1);
+  // 每组两条，组数多时整体高度容易顶到底部字幕带 —— 上限按组数收敛，
+  // 而不是固定值：四组时 rowH≈104，两组时仍能用满 120。
+  const rowH = Math.min(120, 430 / Math.max(groups.length, 1));
+
+  return (
+    <ChartFrame
+      title={title}
+      subtitle={subtitle}
+      footnote={footnote}
+      slideNumber={slideNumber}
+      totalSlides={totalSlides}
+    >
+      <div style={{ width: "100%", paddingRight: 40 }}>
+        {/* legend doubles as the column header so the two bars never need re-explaining */}
+        <div style={{ display: "flex", alignItems: "center", gap: 24, marginBottom: 18 }}>
+          <div style={{ flex: "0 0 330px" }} />
+          <div style={{ flex: 1, display: "flex", gap: 28, fontSize: 24, color: DS.muted }}>
+            <span style={{ color: DS.invalid }}>■ {leftLabel}</span>
+            <span style={{ color: DS.accent }}>■ {rightLabel}</span>
+            {unit && <span>· {unit}</span>}
+          </div>
+          <div style={{ flex: "0 0 150px", fontSize: 22, color: DS.muted, textAlign: "right" }}>
+            {ratioHeader}
+          </div>
+        </div>
+
+        {groups.map((g, i) => (
+          <Row key={g.label} group={g} max={max} delay={10 + i * 9} rowH={rowH} />
+        ))}
+      </div>
+    </ChartFrame>
+  );
+};

--- a/remotion/src/compositions/charts/RangeSpan.tsx
+++ b/remotion/src/compositions/charts/RangeSpan.tsx
@@ -1,0 +1,195 @@
+/**
+ * RangeSpan — compare how far two quantities travel between percentiles.
+ *
+ * Use when the argument is "factor A varies far more than factor B, so A wins
+ * regardless of B". Log-scaled tracks make a 462× and a 71× span visually
+ * comparable; the multiplier is the punchline and lands last.
+ *
+ * script.json:
+ *   {
+ *     "type": "rangeSpan",
+ *     "title": "池子的跨度，远大于份额的跨度",
+ *     "chart": {
+ *       "rows": [
+ *         {"label": "日成交额 vol24", "lo": 6.5, "hi": 3001, "loLabel": "$6.5", "hiLabel": "$3,001",
+ *          "span": "462×", "tone": "accent", "note": "决定 pool，正相关"},
+ *         {"label": "队列份额 q", "lo": 0.0042, "hi": 0.30, "loLabel": "0.00", "hiLabel": "0.30",
+ *          "span": "71×", "note": "冷门的优势项，反相关"}
+ *       ],
+ *       "axisNote": "p10 → p90（对数刻度）"
+ *     }
+ *   }
+ */
+import React from "react";
+import { interpolate } from "remotion";
+import { ChartFrame, DS, useGrow } from "./chartBase";
+
+export type SpanRow = {
+  label: string;
+  lo: number;
+  hi: number;
+  loLabel?: string;
+  hiLabel?: string;
+  span: string;
+  tone?: "accent" | "invalid" | "verified" | "neutral";
+  note?: string;
+};
+
+const toneColor = (tone?: SpanRow["tone"]) =>
+  tone === "accent" ? DS.accent
+    : tone === "invalid" ? DS.invalid
+    : tone === "verified" ? DS.verified
+    : "#4a5568";
+
+const SpanTrack: React.FC<{ row: SpanRow; globalLo: number; globalHi: number; delay: number }> = ({
+  row,
+  globalLo,
+  globalHi,
+  delay,
+}) => {
+  const g = useGrow(delay);
+  const gSpan = useGrow(delay + 16);
+  const c = toneColor(row.tone);
+
+  // log scale so a 462× and a 71× span are both legible on one axis
+  const lg = (v: number) => Math.log10(Math.max(v, 1e-6));
+  const pos = (v: number) => ((lg(v) - lg(globalLo)) / (lg(globalHi) - lg(globalLo))) * 100;
+  const left = pos(row.lo);
+  const right = pos(row.hi);
+  const width = interpolate(g, [0, 1], [0, right - left]);
+
+  return (
+    <div style={{ marginBottom: 54 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 14 }}>
+        <div style={{ fontSize: 32, fontWeight: 700 }}>{row.label}</div>
+        {row.note && <div style={{ fontSize: 24, color: DS.muted }}>{row.note}</div>}
+      </div>
+      <div style={{ position: "relative", height: 60 }}>
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: 26,
+            height: 4,
+            background: DS.panel,
+            borderRadius: 2,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: `${left}%`,
+            top: 22,
+            width: `${width}%`,
+            height: 12,
+            background: c,
+            borderRadius: 6,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: `${left}%`,
+            top: 14,
+            transform: "translateX(-50%)",
+            width: 4,
+            height: 28,
+            background: c,
+            opacity: g,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: `${left + width}%`,
+            top: 14,
+            transform: "translateX(-50%)",
+            width: 4,
+            height: 28,
+            background: c,
+            opacity: g,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: `${left}%`,
+            top: 0,
+            transform: "translateX(-50%)",
+            fontSize: 22,
+            fontFamily: DS.mono,
+            color: DS.muted,
+            opacity: g,
+          }}
+        >
+          {row.loLabel ?? row.lo}
+        </div>
+        <div
+          style={{
+            position: "absolute",
+            left: `${left + width}%`,
+            top: 0,
+            transform: "translateX(-50%)",
+            fontSize: 22,
+            fontFamily: DS.mono,
+            color: DS.muted,
+            opacity: g,
+          }}
+        >
+          {row.hiLabel ?? row.hi}
+        </div>
+        <div
+          style={{
+            position: "absolute",
+            left: `calc(${left + width}% + 34px)`,
+            top: -6,
+            fontSize: 44,
+            fontWeight: 900,
+            fontFamily: DS.mono,
+            color: c,
+            opacity: gSpan,
+            transform: `scale(${interpolate(gSpan, [0, 1], [0.7, 1])})`,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {row.span}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const RangeSpan: React.FC<{
+  title: string;
+  subtitle?: string;
+  footnote?: string;
+  slideNumber?: number;
+  totalSlides?: number;
+  rows: SpanRow[];
+  axisNote?: string;
+}> = ({ title, subtitle, footnote, slideNumber, totalSlides, rows, axisNote }) => {
+  const globalLo = Math.min(...rows.map((r) => r.lo));
+  const globalHi = Math.max(...rows.map((r) => r.hi));
+  return (
+    <ChartFrame
+      title={title}
+      subtitle={subtitle}
+      footnote={footnote}
+      slideNumber={slideNumber}
+      totalSlides={totalSlides}
+    >
+      {/* 倍数标签画在轨道右端之外，需为最长的一条预留，否则会压住轨道或出画 */}
+      <div style={{ width: "100%", paddingRight: 240 }}>
+        {rows.map((r, i) => (
+          <SpanTrack key={r.label} row={r} globalLo={globalLo} globalHi={globalHi} delay={10 + i * 20} />
+        ))}
+        {axisNote && (
+          <div style={{ fontSize: 22, color: DS.muted, fontFamily: DS.mono, marginTop: -20 }}>
+            {axisNote}
+          </div>
+        )}
+      </div>
+    </ChartFrame>
+  );
+};

--- a/remotion/src/compositions/charts/Scatter.tsx
+++ b/remotion/src/compositions/charts/Scatter.tsx
@@ -1,0 +1,204 @@
+/**
+ * Scatter — correlation cloud with an optional trend line and r annotation.
+ *
+ * Use when the claim is about direction of association ("the first half of that
+ * intuition is right, the second half isn't"). Points fade in as a cloud, then
+ * the trend line draws, then r lands — so the viewer sees the shape before the
+ * statistic, not after.
+ *
+ * Points may be supplied directly, or generated deterministically from a target
+ * r via `synth` when the real cloud is too dense to ship as JSON. Synthetic
+ * clouds MUST be labelled in the footnote — see the guard in the component.
+ *
+ * script.json:
+ *   {
+ *     "type": "scatter",
+ *     "title": "那个直觉的前半段是对的",
+ *     "chart": {
+ *       "xLabel": "log 日成交额",
+ *       "yLabel": "log 队列份额",
+ *       "r": -0.315,
+ *       "rLabel": "corr(log vol24, log q)",
+ *       "synth": {"n": 160, "seed": 193},
+ *       "synthDisclosure": "示意云，r 与实测一致；逐点原始数据见 artifact"
+ *     }
+ *   }
+ */
+import React from "react";
+import { interpolate, useCurrentFrame } from "remotion";
+import { ChartFrame, DS, useGrow } from "./chartBase";
+
+export type Pt = { x: number; y: number };
+
+/** Deterministic LCG — same seed always yields the same cloud across renders. */
+const lcg = (seed: number) => {
+  let s = seed >>> 0 || 1;
+  return () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+};
+
+/** Box-Muller from a seeded uniform source. */
+const synthCloud = (n: number, r: number, seed: number): Pt[] => {
+  const rand = lcg(seed);
+  const pts: Pt[] = [];
+  for (let i = 0; i < n; i++) {
+    const u1 = Math.max(rand(), 1e-9);
+    const u2 = rand();
+    const z0 = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+    const z1 = Math.sqrt(-2 * Math.log(u1)) * Math.sin(2 * Math.PI * u2);
+    pts.push({ x: z0, y: r * z0 + Math.sqrt(Math.max(1 - r * r, 0)) * z1 });
+  }
+  return pts;
+};
+
+export const Scatter: React.FC<{
+  title: string;
+  subtitle?: string;
+  footnote?: string;
+  slideNumber?: number;
+  totalSlides?: number;
+  points?: Pt[];
+  synth?: { n: number; seed: number };
+  synthDisclosure?: string;
+  r: number;
+  rLabel?: string;
+  xLabel?: string;
+  yLabel?: string;
+}> = ({
+  title,
+  subtitle,
+  footnote,
+  slideNumber,
+  totalSlides,
+  points,
+  synth,
+  synthDisclosure,
+  r,
+  rLabel,
+  xLabel,
+  yLabel,
+}) => {
+  const frame = useCurrentFrame();
+  const gLine = useGrow(30);
+  const gR = useGrow(46);
+
+  const pts = points ?? (synth ? synthCloud(synth.n, r, synth.seed) : []);
+  const isSynth = !points && Boolean(synth);
+
+  const xs = pts.map((p) => p.x);
+  const ys = pts.map((p) => p.y);
+  const xLo = Math.min(...xs, -3), xHi = Math.max(...xs, 3);
+  const yLo = Math.min(...ys, -3), yHi = Math.max(...ys, 3);
+  const px = (x: number) => ((x - xLo) / (xHi - xLo)) * 100;
+  const py = (y: number) => (1 - (y - yLo) / (yHi - yLo)) * 100;
+
+  const W = 1180, H = 560;
+
+  return (
+    <ChartFrame
+      title={title}
+      subtitle={subtitle}
+      slideNumber={slideNumber}
+      totalSlides={totalSlides}
+      footnote={
+        // A synthetic cloud must always say so on-screen — a shape that looks
+        // like measured data but isn't is exactly the kind of thing that gets
+        // screenshotted and quoted back later.
+        [footnote, isSynth ? synthDisclosure ?? "示意云（非逐点实测），r 取自实测" : null]
+          .filter(Boolean)
+          .join(" · ")
+      }
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 40, width: "100%" }}>
+        <div style={{ position: "relative", width: W, height: H, flex: "0 0 auto" }}>
+          <div style={{ position: "absolute", inset: 0, background: DS.panel, borderRadius: 14 }} />
+          {[25, 50, 75].map((g) => (
+            <React.Fragment key={g}>
+              <div style={{ position: "absolute", left: `${g}%`, top: 0, bottom: 0, width: 1, background: "#222a36" }} />
+              <div style={{ position: "absolute", top: `${g}%`, left: 0, right: 0, height: 1, background: "#222a36" }} />
+            </React.Fragment>
+          ))}
+
+          {pts.map((p, i) => {
+            const appear = interpolate(frame - 6 - (i % 40) * 0.5, [0, 10], [0, 1], {
+              extrapolateLeft: "clamp",
+              extrapolateRight: "clamp",
+            });
+            return (
+              <div
+                key={i}
+                style={{
+                  position: "absolute",
+                  left: `${px(p.x)}%`,
+                  top: `${py(p.y)}%`,
+                  width: 9,
+                  height: 9,
+                  marginLeft: -4.5,
+                  marginTop: -4.5,
+                  borderRadius: "50%",
+                  background: DS.accent,
+                  opacity: appear * 0.55,
+                }}
+              />
+            );
+          })}
+
+          {/* trend line: y = r·x on the standardised cloud */}
+          <svg style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}>
+            <line
+              x1={`${px(xLo)}%`}
+              y1={`${py(r * xLo)}%`}
+              x2={`${px(xLo + (xHi - xLo) * gLine)}%`}
+              y2={`${py(r * (xLo + (xHi - xLo) * gLine))}%`}
+              stroke={DS.invalid}
+              strokeWidth={4}
+              strokeLinecap="round"
+            />
+          </svg>
+
+          {yLabel && (
+            <div
+              style={{
+                position: "absolute",
+                left: -14,
+                top: "50%",
+                transform: "translate(-100%,-50%) rotate(-90deg)",
+                fontSize: 24,
+                color: DS.muted,
+                fontFamily: DS.mono,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {yLabel}
+            </div>
+          )}
+          {xLabel && (
+            <div
+              style={{
+                position: "absolute",
+                bottom: -40,
+                left: "50%",
+                transform: "translateX(-50%)",
+                fontSize: 24,
+                color: DS.muted,
+                fontFamily: DS.mono,
+              }}
+            >
+              {xLabel}
+            </div>
+          )}
+        </div>
+
+        <div style={{ flex: 1, opacity: gR, transform: `translateX(${interpolate(gR, [0, 1], [24, 0])}px)` }}>
+          <div style={{ fontSize: 26, color: DS.muted, marginBottom: 10 }}>{rLabel ?? "corr"}</div>
+          <div style={{ fontSize: 92, fontWeight: 900, fontFamily: DS.mono, color: DS.invalid, letterSpacing: "-0.04em" }}>
+            {r > 0 ? "+" : "−"}
+            {Math.abs(r).toFixed(3)}
+          </div>
+        </div>
+      </div>
+    </ChartFrame>
+  );
+};

--- a/remotion/src/compositions/charts/ThresholdGrid.tsx
+++ b/remotion/src/compositions/charts/ThresholdGrid.tsx
@@ -1,0 +1,116 @@
+/**
+ * ThresholdGrid — one cell per category against a pass/fail threshold.
+ *
+ * Use when the finding is an absence: not "this one is low" but "every single
+ * one is zero". Cells land one after another so the repetition is felt, then a
+ * verdict line states what the uniformity means. A bar chart would waste its
+ * strength here — there is nothing to compare, which is the whole point.
+ *
+ * script.json:
+ *   {
+ *     "type": "thresholdGrid",
+ *     "title": "冷门半 · 能过官方 $1 日结门槛的比例",
+ *     "chart": {
+ *       "cells": [
+ *         {"label": "Crypto", "value": "0%"},
+ *         {"label": "Economics/Culture/Weather", "value": "0%"},
+ *         {"label": "Finance/Politics/Tech", "value": "0%"},
+ *         {"label": "Sports", "value": "0%"}
+ *       ],
+ *       "verdict": "四个品类，无一例外 —— 一分钱拿不到"
+ *     }
+ *   }
+ */
+import React from "react";
+import { interpolate } from "remotion";
+import { ChartFrame, DS, useGrow } from "./chartBase";
+
+export type ThresholdCell = {
+  label: string;
+  value: string;
+  /** default fail = the value is below the bar; pass flips it to the verified colour */
+  state?: "fail" | "pass";
+};
+
+const Cell: React.FC<{ cell: ThresholdCell; delay: number }> = ({ cell, delay }) => {
+  const g = useGrow(delay);
+  const fail = cell.state !== "pass";
+  const c = fail ? DS.invalid : DS.verified;
+  return (
+    <div
+      style={{
+        flex: 1,
+        background: DS.panel,
+        border: `2px solid ${c}33`,
+        borderRadius: 18,
+        padding: "34px 28px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 14,
+        opacity: g,
+        transform: `translateY(${interpolate(g, [0, 1], [24, 0])}px)`,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 78,
+          fontWeight: 900,
+          fontFamily: DS.mono,
+          color: c,
+          letterSpacing: "-0.04em",
+          lineHeight: 1,
+        }}
+      >
+        {cell.value}
+      </div>
+      <div style={{ fontSize: 22, color: DS.muted, textAlign: "center", lineHeight: 1.35 }}>
+        {cell.label}
+      </div>
+    </div>
+  );
+};
+
+export const ThresholdGrid: React.FC<{
+  title: string;
+  subtitle?: string;
+  footnote?: string;
+  slideNumber?: number;
+  totalSlides?: number;
+  cells: ThresholdCell[];
+  verdict?: string;
+}> = ({ title, subtitle, footnote, slideNumber, totalSlides, cells, verdict }) => {
+  const gVerdict = useGrow(12 + cells.length * 8);
+  return (
+    <ChartFrame
+      title={title}
+      subtitle={subtitle}
+      footnote={footnote}
+      slideNumber={slideNumber}
+      totalSlides={totalSlides}
+    >
+      <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: 40 }}>
+        <div style={{ display: "flex", gap: 24 }}>
+          {cells.map((c, i) => (
+            <Cell key={c.label} cell={c} delay={10 + i * 8} />
+          ))}
+        </div>
+        {verdict && (
+          <div
+            style={{
+              fontSize: 40,
+              fontWeight: 800,
+              textAlign: "center",
+              color: DS.text,
+              opacity: gVerdict,
+              transform: `translateY(${interpolate(gVerdict, [0, 1], [14, 0])}px)`,
+            }}
+          >
+            {verdict}
+          </div>
+        )}
+      </div>
+    </ChartFrame>
+  );
+};

--- a/remotion/src/compositions/charts/chartBase.tsx
+++ b/remotion/src/compositions/charts/chartBase.tsx
@@ -1,0 +1,107 @@
+/**
+ * chartBase — shared foundation for every data-visualisation slide.
+ *
+ * Why this exists (2026-08-18): the pipeline had no chart primitives at all.
+ * A deck whose own pre-production gate required "~70% real data visualisation"
+ * shipped with 0% — not because anyone skipped a step, but because the only
+ * building blocks available were text slides and text-laid-out tables. The gate
+ * was a sentence in a markdown file; nothing could turn it into pixels.
+ *
+ * Every chart slide reads its palette from config/design-system.json via
+ * this module, so covers, frames and charts cannot drift apart again.
+ */
+import React from "react";
+import { interpolate, spring, useCurrentFrame, useVideoConfig } from "remotion";
+import ds from "../../../../config/design-system.json";
+
+export const DS = {
+  canvas: ds.canvas.base,
+  panel: ds.canvas.panel,
+  text: ds.text.primary,
+  muted: ds.text.muted,
+  accent: ds.semantic.accent,
+  accentDeep: ds.semantic.accentDeep,
+  verified: ds.semantic.verified,
+  invalid: ds.semantic.invalid,
+  sans: ds.typography.sans.join(", "),
+  mono: ds.typography.mono.join(", "),
+  safeX: ds.layout.safeAreaX,
+  safeY: ds.layout.safeAreaY,
+} as const;
+
+/** Eased 0→1 used by every chart so growth animations feel like one system. */
+export const useGrow = (delayFrames = 0, damping = 18) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  return spring({ frame: frame - delayFrames, fps, config: { damping, mass: 0.6 } });
+};
+
+/** Count-up for numeric labels; respects the same delay as the bar it labels. */
+export const useCountUp = (target: number, delayFrames = 0, durationFrames = 24) => {
+  const frame = useCurrentFrame();
+  return interpolate(frame - delayFrames, [0, durationFrames], [0, target], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+};
+
+/** Vertical space reserved at the bottom of every chart for the captions overlay. */
+const CAPTION_BAND = 132;
+
+export const ChartFrame: React.FC<{
+  title: string;
+  subtitle?: string;
+  footnote?: string;
+  slideNumber?: number;
+  totalSlides?: number;
+  children: React.ReactNode;
+}> = ({ title, subtitle, footnote, slideNumber, totalSlides, children }) => {
+  const t = useGrow(0);
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        background: DS.canvas,
+        padding: `${DS.safeY}px ${DS.safeX}px`,
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: DS.sans,
+        color: DS.text,
+      }}
+    >
+      <div style={{ opacity: t, transform: `translateY(${interpolate(t, [0, 1], [18, 0])}px)` }}>
+        <div style={{ fontSize: 58, fontWeight: 800, letterSpacing: "-0.03em" }}>{title}</div>
+        {subtitle && (
+          <div style={{ fontSize: 30, color: DS.muted, marginTop: 12 }}>{subtitle}</div>
+        )}
+      </div>
+
+      {/* CaptionsLayer 覆盖在所有镜之上，其基线距画布底 96px（design-system.layout）。
+          文字卡不受影响，但图表会被字幕压住 —— 实测柱状条与散点云都被遮过。
+          因此内容区底部预留一条字幕带，图表永远画在它上方。 */}
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          marginTop: 36,
+          paddingBottom: CAPTION_BAND,
+        }}
+      >
+        {children}
+      </div>
+
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end" }}>
+        <div style={{ fontSize: 22, color: DS.muted, fontFamily: DS.mono, maxWidth: 1300 }}>
+          {footnote}
+        </div>
+        {slideNumber != null && totalSlides != null && (
+          <div style={{ fontSize: 20, color: DS.muted, fontFamily: DS.mono }}>
+            {slideNumber} / {totalSlides}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/remotion/tsconfig.json
+++ b/remotion/tsconfig.json
@@ -6,6 +6,7 @@
     "jsx": "react-jsx",
     "strict": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "lib": ["DOM", "ES2020"]
   },

--- a/scripts/align.py
+++ b/scripts/align.py
@@ -17,6 +17,7 @@ Writes:
 Usage:
     python scripts/align.py <project_dir> [--fps 30] [--model base]
 """
+import re
 import argparse
 import json
 from pathlib import Path
@@ -318,6 +319,10 @@ def main() -> int:
 
     for wav in wavs:
         idx = wav.stem  # "00", "01", ...
+        # 只认 NN.wav。各 QA 步骤会留下 NN.before-phantom-head.wav 这类备份，
+        # 它们不是音轨，撞上 int() 会让整条渲染在最后一步崩掉（2026-08-10 实例）。
+        if not re.fullmatch(r"\d+", idx):
+            continue
         slide_idx = int(idx)
         caption_source = None
         if script and slide_idx < len(script.get("slides", [])):

--- a/scripts/check_gate.py
+++ b/scripts/check_gate.py
@@ -19,7 +19,7 @@ import sys
 from pathlib import Path
 
 # Types that put real, data-driven graphics on screen.
-CHART_TYPES = {"barCompare", "rangeSpan", "scatter"}
+CHART_TYPES = {"barCompare", "rangeSpan", "scatter", "dualColumn", "thresholdGrid"}
 # Types that are words on a background, however nicely arranged.
 TEXT_TYPES = {"content", "text", "transition", "cover", "code"}
 # Tables sit in between: real numbers, but laid out as text.

--- a/scripts/check_gate.py
+++ b/scripts/check_gate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""check_gate.py — turn PREPRODUCTION-GATE.md claims into assertions against script.json.
+
+Why this exists (2026-08-18): a deck's gate said "~70% real data visualisation,
+text-only cards < 30%". The render QA dutifully counted and reported "3/17 = 18%,
+well under the 50% red line" — by counting text-laid-out tables as non-text. The
+deck shipped with zero charts. The gate was prose, the QA was a judgement call,
+and nothing compared the two.
+
+This runs before render and fails loudly when the deck does not match its gate.
+
+Usage:
+    python3 check_gate.py <project_dir>            # exit 2 on violation
+    python3 check_gate.py <project_dir> --warn     # report only, always exit 0
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+# Types that put real, data-driven graphics on screen.
+CHART_TYPES = {"barCompare", "rangeSpan", "scatter"}
+# Types that are words on a background, however nicely arranged.
+TEXT_TYPES = {"content", "text", "transition", "cover", "code"}
+# Tables sit in between: real numbers, but laid out as text.
+TABLE_TYPES = {"table", "formula"}
+
+
+def parse_gate(gate_path: Path) -> dict:
+    """Pull the numeric promises out of the gate prose. Absent → no constraint."""
+    if not gate_path.exists():
+        return {}
+    text = gate_path.read_text()
+    out = {}
+    m = re.search(r"(?:约\s*)?(\d+)\s*%\s*(?:的\s*)?真实数据可视化", text)
+    if m:
+        out["min_chart_pct"] = int(m.group(1))
+    m = re.search(r"纯文字卡\s*[<＜]\s*(\d+)\s*%", text)
+    if m:
+        out["max_text_pct"] = int(m.group(1))
+    return out
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 1
+    project = Path(sys.argv[1])
+    warn_only = "--warn" in sys.argv
+
+    script_path = project / "script.json"
+    if not script_path.exists():
+        print(f"script.json not found: {script_path}", file=sys.stderr)
+        return 1
+
+    slides = json.loads(script_path.read_text()).get("slides", [])
+    n = len(slides) or 1
+    charts = [s for s in slides if s.get("type") in CHART_TYPES]
+    texts = [s for s in slides if s.get("type") in TEXT_TYPES]
+    tables = [s for s in slides if s.get("type") in TABLE_TYPES]
+
+    chart_pct = len(charts) / n * 100
+    text_pct = len(texts) / n * 100
+
+    gate = parse_gate(project / "PREPRODUCTION-GATE.md")
+
+    print(f"镜数 {n} · 图表 {len(charts)} ({chart_pct:.0f}%) · "
+          f"表格/公式 {len(tables)} ({len(tables)/n*100:.0f}%) · "
+          f"纯文字 {len(texts)} ({text_pct:.0f}%)")
+    if not gate:
+        print("PREPRODUCTION-GATE.md 未声明画面构成 → 无约束可检")
+        return 0
+
+    violations = []
+    if "min_chart_pct" in gate and chart_pct < gate["min_chart_pct"]:
+        violations.append(
+            f"gate 要求真实数据可视化 ≥{gate['min_chart_pct']}%，实际 {chart_pct:.0f}%"
+            f"（{len(charts)}/{n} 镜）。"
+            f"表格与公式不计入 —— 它们是文字排版的数字，不是数据可视化。"
+        )
+    if "max_text_pct" in gate and text_pct > gate["max_text_pct"]:
+        violations.append(
+            f"gate 要求纯文字卡 <{gate['max_text_pct']}%，实际 {text_pct:.0f}%"
+            f"（{len(texts)}/{n} 镜）"
+        )
+
+    if not violations:
+        print("✅ 与 PREPRODUCTION-GATE 声明一致")
+        return 0
+
+    print("\n❌ 与 PREPRODUCTION-GATE 声明不符：", file=sys.stderr)
+    for v in violations:
+        print(f"   · {v}", file=sys.stderr)
+    print(f"\n   可用图表类型：{', '.join(sorted(CHART_TYPES))}"
+          f"（用法见 remotion/src/compositions/charts/*.tsx 顶部注释）", file=sys.stderr)
+    if warn_only:
+        print("   (--warn：仅报告，不阻断)", file=sys.stderr)
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_gate.py
+++ b/scripts/check_gate.py
@@ -20,18 +20,34 @@ from pathlib import Path
 
 # Types that put real, data-driven graphics on screen.
 CHART_TYPES = {"barCompare", "rangeSpan", "scatter", "dualColumn", "thresholdGrid"}
-# Types that are words on a background, however nicely arranged.
-TEXT_TYPES = {"content", "text", "transition", "cover", "code"}
+# 结构镜：开场、结尾、转场。每条片子必有，不是"本可用图表却用了文字"。
+# 把它们计入纯文字卡会让任何片子都超标 —— 一条 15 镜的片子光开场+结尾+转场就占 20%。
+STRUCTURAL_TYPES = {"cover", "transition"}
+# 纯文字卡：承载论点、本可以数据可视化、却只用了文字排版的镜。
+TEXT_TYPES = {"content", "text", "code"}
 # Tables sit in between: real numbers, but laid out as text.
 TABLE_TYPES = {"table", "formula"}
 
 
 def parse_gate(gate_path: Path) -> dict:
-    """Pull the numeric promises out of the gate prose. Absent → no constraint."""
+    """把 gate 的承诺解析成可断言的约束。缺失 → 无约束。
+
+    优先识别**清单式**判据（2026-08-18 起的推荐写法）：gate 用一张表逐项列出
+    必须出现的画面及其 slide type，检查器逐个确认 script.json 里真有那个 type。
+    百分比判据仍兼容，但不推荐 —— 它随片长漂移，且给了"重新分类蒙混过关"的空间：
+    一份要求 70% 数据可视化的片子曾以 0% 出厂，QA 把文字排版的 table 算成了非文字卡，
+    报出"18%，红线以内"。清单没有这个空间。
+    """
     if not gate_path.exists():
         return {}
     text = gate_path.read_text()
     out = {}
+
+    # 清单式：表格行里带反引号包住的 slide type
+    required = re.findall(r"\|\s*[①-⑩\d]+\s*\|[^|]*\|\s*`([A-Za-z]+)`\s*\|", text)
+    if required:
+        out["required_types"] = required
+
     m = re.search(r"(?:约\s*)?(\d+)\s*%\s*(?:的\s*)?真实数据可视化", text)
     if m:
         out["min_chart_pct"] = int(m.group(1))
@@ -58,6 +74,7 @@ def main() -> int:
     charts = [s for s in slides if s.get("type") in CHART_TYPES]
     texts = [s for s in slides if s.get("type") in TEXT_TYPES]
     tables = [s for s in slides if s.get("type") in TABLE_TYPES]
+    structural = [s for s in slides if s.get("type") in STRUCTURAL_TYPES]
 
     chart_pct = len(charts) / n * 100
     text_pct = len(texts) / n * 100
@@ -66,12 +83,27 @@ def main() -> int:
 
     print(f"镜数 {n} · 图表 {len(charts)} ({chart_pct:.0f}%) · "
           f"表格/公式 {len(tables)} ({len(tables)/n*100:.0f}%) · "
-          f"纯文字 {len(texts)} ({text_pct:.0f}%)")
+          f"纯文字 {len(texts)} ({text_pct:.0f}%) · "
+          f"结构镜 {len(structural)}（开场/结尾/转场，不计入纯文字卡）")
     if not gate:
         print("PREPRODUCTION-GATE.md 未声明画面构成 → 无约束可检")
         return 0
 
     violations = []
+
+    # 清单判据优先：逐项确认，缺哪项报哪项
+    if "required_types" in gate:
+        present = {s.get("type") for s in slides}
+        missing = [t for t in gate["required_types"] if t not in present]
+        print(f"gate 清单：{len(gate['required_types'])} 项必需画面 · "
+              f"已实现 {len(gate['required_types']) - len(missing)} 项")
+        for t in gate["required_types"]:
+            print(f"   {'✅' if t in present else '❌'} {t}")
+        if missing:
+            violations.append(f"gate 清单缺 {len(missing)} 项：{', '.join(missing)}")
+        # 清单已给出确定判据时，百分比不再作为独立约束
+        gate.pop("min_chart_pct", None)
+
     if "min_chart_pct" in gate and chart_pct < gate["min_chart_pct"]:
         violations.append(
             f"gate 要求真实数据可视化 ≥{gate['min_chart_pct']}%，实际 {chart_pct:.0f}%"

--- a/scripts/gen_video_cover.py
+++ b/scripts/gen_video_cover.py
@@ -80,6 +80,42 @@ def fit_text(draw: ImageDraw.ImageDraw, text: str, max_w: int, sizes: list[int],
     return f, bbox[2] - bbox[0], bbox[3] - bbox[1], sizes[-1]
 
 
+def shrink_to_fit(draw, text, max_w, size_max, *, floor_ratio=0.35, label=""):
+    """按宽度算出真正装得下的字号，而不是试几档就放弃。
+
+    2026-08-11：原来写成 `for size in [max, .9x, .8x, .7x]: if fits: break`，
+    循环跑完没命中也照样往下画 —— 于是 OKXAI 示例封面的 `incomplete`
+    在 9:16 上被画出画布，左右各截掉一截，屏幕上剩 `comple`。
+    截断不只是难看：`incomplete`(对不上) 被截成看起来像 `complete`(通过)，
+    **封面把整条片子的结论说反了**，而生成器一声不吭。
+
+    版式当初是给 `+128%` `95%` 这种短数字设计的，英文单词一进来就漏。
+    字宽随字号近似线性，所以先量一次再按比例缩，一步到位；
+    收窄到 floor_ratio 以下说明这个词根本不该放这个位置，出声警告。
+    """
+    lo, hi = int(size_max * floor_ratio), size_max
+    best = lo
+    while lo <= hi:                      # 二分，字宽对字号单调
+        mid = (lo + hi) // 2
+        bbox = draw.textbbox((0, 0), text, font=make_font(mid))
+        if (bbox[2] - bbox[0]) <= max_w:
+            best, lo = mid, mid + 1
+        else:
+            hi = mid - 1
+
+    f = make_font(best)
+    bbox = draw.textbbox((0, 0), text, font=f)
+    w = bbox[2] - bbox[0]
+    if w > max_w:
+        # 到了地板还是超宽 —— 只有这时才可能溢出，必须让人看见
+        print(f"  ⚠️  封面{label}「{text}」到最小字号 {best}px 仍超宽 "
+              f"({w} > {max_w})，会被裁。换更短的词。", flush=True)
+    elif best < size_max * 0.6:
+        print(f"  ⚠️  封面{label}「{text}」被压到 {best}px "
+              f"（上限 {size_max}px 的 {best/size_max:.0%}），视觉冲击已经没了。", flush=True)
+    return f, w, bbox[3] - bbox[1]
+
+
 def _render_data_contrast(img, draw, W, H, data, accent_h):
     """Plan A 数字反差版式 — Leo article 招牌:
     layout (9x16 1080×1920):
@@ -118,16 +154,7 @@ def _render_data_contrast(img, draw, W, H, data, accent_h):
     # === TOP_NUM (灰色超大字 - "被抢的") ===
     # 自适应字号 - 按 H 缩放（9:16 H=1920 → ~360, 16:9 H=1080 → ~200）
     top_size_max = int(H * 0.19)
-    candidates = [top_size_max, int(top_size_max*0.9), int(top_size_max*0.8), int(top_size_max*0.7)]
-    f_top = None
-    for size in candidates:
-        f_top = make_font(size)
-        bbox = draw.textbbox((0, 0), top_num, font=f_top)
-        if (bbox[2] - bbox[0]) <= max_w:
-            break
-    bbox = draw.textbbox((0, 0), top_num, font=f_top)
-    lw = bbox[2] - bbox[0]
-    th = bbox[3] - bbox[1]
+    f_top, lw, th = shrink_to_fit(draw, top_num, max_w, top_size_max, label="top_num")
     draw.text(((W - lw) // 2, y_cursor), top_num, fill="#3a3f47", font=f_top)
     y_cursor += int(th + H * 0.018)
 
@@ -150,16 +177,7 @@ def _render_data_contrast(img, draw, W, H, data, accent_h):
 
     # === BOTTOM_NUM (橙色超大字 - "你留的") - 按 H 缩放 ===
     bot_size_max = int(H * 0.23)
-    cand = [bot_size_max, int(bot_size_max*0.9), int(bot_size_max*0.8), int(bot_size_max*0.7)]
-    f_bot = None
-    for size in cand:
-        f_bot = make_font(size)
-        bbox = draw.textbbox((0, 0), bottom_num, font=f_bot)
-        if (bbox[2] - bbox[0]) <= max_w:
-            break
-    bbox = draw.textbbox((0, 0), bottom_num, font=f_bot)
-    lw = bbox[2] - bbox[0]
-    th = bbox[3] - bbox[1]
+    f_bot, lw, th = shrink_to_fit(draw, bottom_num, max_w, bot_size_max, label="bottom_num")
     draw.text(((W - lw) // 2, y_cursor), bottom_num, fill=ACCENT, font=f_bot)
     y_cursor += int(th + H * 0.02)
 

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -71,8 +71,20 @@ cd "$KIT_ROOT/remotion"
 # Note: Remotion v4 --props expects either inline JSON or doesn't auto-load
 # file paths reliably. We pass file content via $(cat) so the JSON is inlined.
 PROPS_JSON="$(cat "$PROJECT/metadata.json")"
-./node_modules/.bin/remotion render src/index.ts Main "$PROJECT/out/full.mp4" \
+# --timeout：默认 30s/帧，重镜（大表格 + Ken Burns）在长片里会超。
+#   超时后 remotion 非零退出，但此前本脚本未检查返回码，整体仍以 exit 0 结束 ——
+#   调用方看到"成功"，out/ 里却没有文件（2026-08-18 实测到一次）。
+REMOTION_FRAME_TIMEOUT="${REMOTION_FRAME_TIMEOUT:-120000}"
+if ! ./node_modules/.bin/remotion render src/index.ts Main "$PROJECT/out/full.mp4" \
   --props="$PROPS_JSON" \
-  --public-dir="$PROJECT/workspace"
+  --public-dir="$PROJECT/workspace" \
+  --timeout="$REMOTION_FRAME_TIMEOUT"; then
+  echo "❌ [4/4] Remotion render 失败 —— 不产出半成品，请勿把上一次的旧文件当本次结果" >&2
+  exit 1
+fi
+if [[ ! -s "$PROJECT/out/full.mp4" ]]; then
+  echo "❌ [4/4] remotion 返回 0 但 out/full.mp4 不存在或为空" >&2
+  exit 1
+fi
 
 echo "✅ done → $PROJECT/out/full.mp4"

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -31,14 +31,26 @@ case "$ALIGN_MODE" in
     ;;
 esac
 
-echo "▶ [1/4] TTS (backend: ${TTS_BACKEND:-fish})"
+echo "▶ [1/4] TTS (backend: ${TTS_BACKEND:-cosyvoice})"
 PYTHON="${PYTHON:-python3}"
-case "${TTS_BACKEND:-fish}" in
+# 默认 cosyvoice：唯一使用本人克隆音色的后端。其余后端是通用音色，
+# 用在本人署名的内容上等于换了个人说话，因此不作默认，也不作兜底。
+# 未知值一律报错退出 —— 旧版 `fish|*` 的通配兜底会把任何拼错的后端名
+# 静默导向付费 API（2026-08-17 即因此在未确认的情况下产生了一次付费消耗）。
+case "${TTS_BACKEND:-cosyvoice}" in
+  cosyvoice)
+    "$PYTHON" "$KIT_ROOT/scripts/tts_cosyvoice.py" "$PROJECT"
+    ;;
   indextts2)
     "$PYTHON" "$KIT_ROOT/scripts/tts_indextts2.py" "$PROJECT"
     ;;
-  fish|*)
+  fish)
+    echo "  ⚠️  fish = 通用音色 + 付费 API，非本人声音。仅供对照测试，不要用于发布内容。" >&2
     "$PYTHON" "$KIT_ROOT/scripts/tts.py" "$PROJECT"
+    ;;
+  *)
+    echo "unsupported TTS_BACKEND: ${TTS_BACKEND} (expected cosyvoice, indextts2 or fish)" >&2
+    exit 2
     ;;
 esac
 

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -31,6 +31,17 @@ case "$ALIGN_MODE" in
     ;;
 esac
 
+# [0/4] 画面构成门 —— 在花钱做 TTS 之前先对一次 gate。
+# 此前 gate 只是 markdown 里的一句话，QA 靠人工判断"哪些算文字卡"，
+# 于是一份要求 70% 数据可视化的片子以 0% 出厂，全程无人报错。
+if [[ -f "$PROJECT/PREPRODUCTION-GATE.md" ]]; then
+  echo "▶ [0/4] 画面构成门"
+  if ! "${PYTHON:-python3}" "$KIT_ROOT/scripts/check_gate.py" "$PROJECT" ${GATE_WARN_ONLY:+--warn}; then
+    echo "   设 GATE_WARN_ONLY=1 可降级为仅告警（需在 RENDER-QA 写明理由）" >&2
+    exit 2
+  fi
+fi
+
 echo "▶ [1/4] TTS (backend: ${TTS_BACKEND:-cosyvoice})"
 PYTHON="${PYTHON:-python3}"
 # 默认 cosyvoice：唯一使用本人克隆音色的后端。其余后端是通用音色，

--- a/scripts/scan_frames.py
+++ b/scripts/scan_frames.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""scan_frames.py — 逐帧扫描内容是否跑出画布安全区。
+
+⚠️ 能力边界（2026-08-18 用阳性对照标定，**读完再决定要不要信它**）：
+    本脚本只能发现「元素跑到画布外」，**不能**发现「元素互相重叠」。
+    而实测中真正出现的三处布局缺陷 —— badge 文字压住标题、倍数标签压住轨道、
+    字幕盖住柱形 —— 全部属于后者：它们都**在安全区之内**，只是彼此叠了。
+
+    阳性对照（作废旧片，含 3 处已知 badge 溢出）：
+      thresh=26 → 35 帧报警，逐帧核对全为背景光晕误报，真问题检出 0
+      thresh=70 → 4 帧报警（开场动画），3 处已知溢出**全部漏检**
+    低阈值全是噪声，高阈值直接失聪，中间不存在可用区间 —— 因为判据本身对不上问题类型。
+
+    因此本脚本**不接入 render.sh，不作为发布门**。
+    要真正拦住重叠与裁切，正确做法是渲染期的 DOM 断言
+    （scrollWidth > clientWidth 判裁切；元素 bbox 相交判重叠），
+    Remotion 渲染时可拿到真实 DOM 尺寸，既准确又零误报 —— 尚未实现。
+
+    留着它的唯一理由：出血（内容真跑到画布外）它确实能抓，而那类问题肉眼反而容易忽略。
+
+原始说明：
+
+为什么存在（2026-08-18）：
+成片自检此前靠抽几帧人眼看。抽样能发现的问题，取决于恰好抽到哪一帧 ——
+而动画是有时间维度的：spring 早期元素是缩小的，count-up 中途数字宽度在变，
+溢出往往只发生在某个瞬间。一条 4 分钟片子里，实测有三处布局问题
+（数值被右缘裁断、倍数标签压住轨道、字幕盖住柱形）全部是靠肉眼偶然撞见的。
+
+本脚本按固定间隔取帧（默认每 0.5 秒），对每帧求非背景像素的包围盒，
+与设计系统的安全区比对。它查的是"有没有东西跑到不该在的地方"，
+不判断好不好看 —— 后者仍需人眼，见 --sheet 产出的审片表。
+
+用法：
+    python3 scan_frames.py <video.mp4>                 # 扫描并报告
+    python3 scan_frames.py <video.mp4> --every 0.25    # 加密采样
+    python3 scan_frames.py <video.mp4> --sheet <dir>   # 另外导出每镜 3 帧供人眼审
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from PIL import Image
+except ImportError:
+    print("需要 Pillow：pip install Pillow", file=sys.stderr)
+    raise SystemExit(1)
+
+KIT = Path(__file__).resolve().parent.parent
+DS = json.loads((KIT / "config" / "design-system.json").read_text())
+SAFE_X = DS["layout"]["safeAreaX"]
+SAFE_Y = DS["layout"]["safeAreaY"]
+# 顶部品牌渐变条横贯全宽，是设计元素不是溢出。不排除它，包围盒永远满幅：
+# 首次运行 263 帧报 169 帧越界，全部源于此。
+BRAND_BAR = DS["layout"].get("brandBarHeight", 0)
+# 允许触到安全区边界本身，只有越过才算问题；再放 8px 容差吸收抗锯齿。
+TOL = 8
+
+
+def probe_duration(path: Path) -> float:
+    out = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", str(path)],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    return float(out or 0)
+
+
+def bbox_of(img: Image.Image, bg, thresh: int = 70, skip_top: int = 0):
+    """高对比元素（文字/图形）的包围盒。
+
+    thresh 必须高到能忽略背景装饰：本设计系统用大面积柔和径向光晕，
+    低阈值会把光晕算成内容，于是包围盒常年满幅 —— 2026-08-18 实测 thresh=26
+    时 263 帧报 35 帧越界，逐帧看全是光晕，无一真实溢出。
+    阈值以作废旧片作阳性对照标定：该片有 3 处已知 badge 溢出，
+    调高后仍须能检出，否则就是把探测器调聋了。
+    """
+    small = img.convert("RGB")
+    w, h = small.size
+    px = small.load()
+    step = 2  # 半采样，够用且快一倍
+    minx, miny, maxx, maxy = w, h, -1, -1
+    for y in range(skip_top, h, step):
+        for x in range(0, w, step):
+            r, g, b = px[x, y]
+            if abs(r - bg[0]) + abs(g - bg[1]) + abs(b - bg[2]) > thresh:
+                if x < minx: minx = x
+                if x > maxx: maxx = x
+                if y < miny: miny = y
+                if y > maxy: maxy = y
+    if maxx < 0:
+        return None
+    return (minx, miny, maxx, maxy)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 1
+    video = Path(sys.argv[1])
+    if not video.exists():
+        print(f"找不到 {video}", file=sys.stderr)
+        return 1
+    every = 0.5
+    if "--every" in sys.argv:
+        every = float(sys.argv[sys.argv.index("--every") + 1])
+
+    dur = probe_duration(video)
+    n = int(dur / every)
+    print(f"{video.name} · {dur:.1f}s · 每 {every}s 取一帧 → {n} 帧")
+    print(f"安全区：左右 {SAFE_X}px 上下 {SAFE_Y}px（容差 {TOL}px）\n")
+
+    violations = []
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td) / "f.png"
+        for i in range(n):
+            t = i * every
+            subprocess.run(
+                ["ffmpeg", "-y", "-ss", str(t), "-i", str(video), "-frames:v", "1",
+                 "-vf", "scale=960:-1", str(tmp), "-loglevel", "error"],
+                check=False,
+            )
+            if not tmp.exists():
+                continue
+            im = Image.open(tmp)
+            scale = im.width / DS["layout"]["width"]
+            bg = im.convert("RGB").getpixel((3, max(4, int(BRAND_BAR * scale) + 2)))
+            if not isinstance(bg, tuple) or len(bg) < 3:
+                continue                      # 非 RGB 帧（极少见）直接跳过，不猜
+            bb = bbox_of(im, bg, skip_top=max(2, int(BRAND_BAR * scale) + 1))
+            if not bb:
+                continue
+            # 换算回 1920 坐标系
+            x0, y0, x1, y1 = [v / scale for v in bb]
+            over = []
+            if x0 < SAFE_X - TOL: over.append(f"左 {SAFE_X - x0:.0f}px")
+            if x1 > DS["layout"]["width"] - SAFE_X + TOL:
+                over.append(f"右 {x1 - (DS['layout']['width'] - SAFE_X):.0f}px")
+            if y0 < SAFE_Y - TOL: over.append(f"上 {SAFE_Y - y0:.0f}px")
+            if y1 > DS["layout"]["height"] - SAFE_Y + TOL:
+                over.append(f"下 {y1 - (DS['layout']['height'] - SAFE_Y):.0f}px")
+            if over:
+                violations.append((t, over))
+
+    if not violations:
+        print("✅ 全部采样帧内容均在安全区内")
+        return 0
+
+    # 连续帧合并成区间，避免同一处问题刷屏
+    merged = []
+    for t, over in violations:
+        if merged and t - merged[-1][1] <= every * 1.5 and merged[-1][2] == over:
+            merged[-1][1] = t
+        else:
+            merged.append([t, t, over])
+
+    print(f"⚠️ {len(violations)} 帧越界，合并为 {len(merged)} 处：")
+    for a, b, over in merged:
+        span = f"{a:.1f}s" if a == b else f"{a:.1f}–{b:.1f}s"
+        print(f"   · {span:>16}  超出：{', '.join(over)}")
+    print("\n注：越界不等于一定有问题（满幅背景、贴边设计会误报），"
+          "但每一处都该看一眼对应帧再放行。")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tts_cosyvoice.py
+++ b/scripts/tts_cosyvoice.py
@@ -253,10 +253,14 @@ def main() -> int:
                 tmp.replace(out)
 
         # per-wav loudnorm 到 -20 LUFS （和 IndexTTS2 流程一致）
+        # ⚠️ 必须显式重设 -ar/-ac/-sample_fmt：ffmpeg 的 loudnorm 滤镜内部按 192kHz
+        # 工作，不指定输出格式时会把 22.05kHz 的语音写成 192kHz —— 文件大 8.7 倍，
+        # 且没有任何警告。上游那次 `-ar 22050` 的转换会被这一步悄悄推翻。
         tmp_ln = out.with_suffix(".ln.wav")
         cp_ln = subprocess.run(
             ["ffmpeg", "-y", "-i", str(out),
              "-af", "loudnorm=I=-20:LRA=7:TP=-3",
+             "-ar", "22050", "-ac", "1", "-sample_fmt", "s16",
              str(tmp_ln), "-loglevel", "error"],
             check=False,
         )

--- a/scripts/tts_cosyvoice.py
+++ b/scripts/tts_cosyvoice.py
@@ -12,10 +12,12 @@ tts_cosyvoice.py — Generate WAV per slide using Alibaba DashScope CosyVoice.
 
 Env:
   DASHSCOPE_API_KEY      (P0 必填)
-  COSYVOICE_MODEL        默认 "cosyvoice-v3.5-plus"
-  COSYVOICE_VOICE_ID     必填；预制音色（默认 voice）或 voice clone 创建后的 id
+  COSYVOICE_MODEL        默认 "cosyvoice-v2"（docstring 此前写 v3.5-plus，与代码不符，已按代码更正）
+  COSYVOICE_VOICE_ID     **必填，无默认**；voice clone 创建后的 id。
+                         未设置直接报错退出 —— 不再 fallback 到预制音色 longxiaochun_v2，
+                         否则 env 漏设会静默生成一整条陌生人声音的片子
   COSYVOICE_FORCE        =1 强制重生成
-  COSYVOICE_SPEED        默认 1.08（与 IndexTTS2 对齐）
+  COSYVOICE_SPEED        默认 1.0（**不倍速**：变速会压掉爆破音）。1.08 是与 IndexTTS2 的对照口径，非生产默认
   COSYVOICE_FORMAT       "wav" / "mp3" 默认 wav
   VOICE_RULES_PATH       optional JSON preprocessing rules; defaults to config sample
 
@@ -167,12 +169,21 @@ def main() -> int:
         return 1
 
     # 2026-05-15 smoke test：v3.5-plus 预制音色名跟文档对不上（可能只支持 voice clone），
-    # 先用 cosyvoice-v2 + longxiaochun_v2 跑通管线。最终生产用 Leo voice clone（target_model 自己指定）。
     model = os.environ.get("COSYVOICE_MODEL", "cosyvoice-v2")
-    voice = os.environ.get("COSYVOICE_VOICE_ID", "longxiaochun_v2")
+    # 不再 fallback 到预制音色。此前默认是 longxiaochun_v2，一旦 env 漏设就会
+    # 静默用陌生人的声音生成整条片，而产物听起来完全正常 —— 只有本人能听出不对。
+    voice = os.environ.get("COSYVOICE_VOICE_ID")
+    if not voice:
+        raise SystemExit(
+            "COSYVOICE_VOICE_ID 未设置。本管线只用本人克隆音色，不接受预制音色兜底。\n"
+            "  取得 voice_id：python scripts/leo_voice_clone_create.py\n"
+            "  仅在明确要对照预制音色时，才显式 export COSYVOICE_VOICE_ID=longxiaochun_v2"
+        )
     fmt = os.environ.get("COSYVOICE_FORMAT", "wav")
+    # 默认 1.0，不倍速：变速会压掉爆破音，是本人明确定过的规则。
+    # 旧默认 1.08 是为对齐 IndexTTS2 的语速，但那属于对照口径，不该成为生产默认。
     try:
-        speed = float(os.environ.get("COSYVOICE_SPEED", "1.08"))
+        speed = float(os.environ.get("COSYVOICE_SPEED", "1.0"))
     except ValueError:
         speed = 1.0
 


### PR DESCRIPTION
Originally this branch only fixed cover text overflowing the canvas. It has since
grown into the work that made two videos, produced a week apart, stop looking like
they came from two different products.

## Why it grew

The two decks did not share a pipeline. One hand-rolled a `tools/` directory of
one-off evidence scripts plus its own `DESIGN.md`; the other fell back to the
generic text template because **the kit had no chart primitives at all**. A deck
whose pre-production gate demanded "~70% real data visualisation" therefore
shipped with 0% — nobody skipped a step, the building blocks did not exist.

## What is in here now

**Chart layer** — five reusable slide types driven from `script.json`:
`barCompare`, `dualColumn`, `rangeSpan`, `scatter`, `thresholdGrid`. All read
their palette from the new `config/design-system.json`, which becomes the single
source of colour truth: values had drifted across four separate definitions
(per-project DESIGN.md, ui-kit theme, hard-coded hex in ContentSlide, more
hard-coded hex in the cover generator).

**Voice backend** — `render.sh` now defaults to CosyVoice and an unrecognised
`TTS_BACKEND` exits non-zero. The old `fish|*` catch-all sent any typo straight
to a paid API, and `COSYVOICE_VOICE_ID` used to fall back to a stock preset
voice. When a channel publishes under someone's own name, a stock voice makes it
someone else talking — and the output sounds perfectly fine, so no QA step
catches it.

**Executable gates** — `check_gate.py` parses the requirements out of
`PREPRODUCTION-GATE.md` and asserts them against `script.json`, running as step 0
of `render.sh` (before the paid TTS call). Checklist-form gates are preferred
over percentages: a percentage drifts with deck length and leaves room to
reclassify your way past it, which is how "18%, well inside the red line" was
reported for a deck that actually contained zero charts.

**Three silent failures fixed** — badge with no overflow guard (3 of 5 badges
overflowed in a real deck, covering the title, with no error); loudnorm silently
overriding the sample rate to 192kHz (8.7x file size); `render.sh` ignoring
remotion's exit code (a per-frame timeout aborted a render at frame 5544 of 7902
and the script still exited 0 with an empty out/).

**One tool deliberately not wired in** — `scan_frames.py` scans frames against
the safe area, and its own docstring explains why it is not a release gate: a
positive control showed the predicate does not match the failure mode. The
defects that actually occur sit *inside* the safe area and merely overlap each
other, which a bounding box cannot see. The right mechanism is a render-time DOM
assertion; not implemented yet.

## CI

`test` is red on a pre-existing failure unrelated to this branch: the
release-alignment test requires `video-explainer.mjs demo` to appear in both
READMEs and it does not. Verified by checking out the branch point (7331784) and
running `npm run check` there — same single failure, 14 pass.