### PR TITLE
video pipeline: data covers, template lock, and platform-specific end cards

### DIFF
--- a/config/design-system.json
+++ b/config/design-system.json
@@ -141,7 +141,18 @@
           "value": "t.me/runesgangalpha"
         }
       ],
-      "excluded": "不放返佣、订阅、课程 —— 那些属于分发文案，不进片子。个别片子要放须在 PREPRODUCTION-GATE 写明理由。"
+      "excluded": "不放返佣、订阅、课程 —— 那些属于分发文案，不进片子。个别片子要放须在 PREPRODUCTION-GATE 写明理由。",
+      "$platformNote": "⚠️ 片尾必须分版。CN 平台（B站/小红书/抖音/视频号）按 T288 现行口径 `no_referral_no_signal_no_hard_cta`：**不放 TG 频道等信号入口**，只留身份与研究站点。X / YouTube / TG 可用完整版。2026-08-18 首次发现：一条 PM 主题视频带着 TG 片尾传上了 B站。",
+      "ctas_cn": [
+        {
+          "label": "作者",
+          "value": "Leo · 一个人 + AI"
+        },
+        {
+          "label": "研究",
+          "value": "leolabs.me"
+        }
+      ]
     }
   }
 }

--- a/config/design-system.json
+++ b/config/design-system.json
@@ -81,5 +81,67 @@
     "$comment": "Cover art inherits canvas/semantic above. Persona is NOT global — see rule.",
     "watermark": "@runes_leo · leolabs.me",
     "personaRule": "Prediction-market content: no persona on the cover. Non-PM content: persona per the 2026-07-29 template."
+  },
+  "template": {
+    "$comment": [
+      "模板锁 —— 定稿于 2026-08-18，Leo 明确要求：模板类的东西定好一次就固定住，不要频繁更新。",
+      "",
+      "变更条件（同时满足才动）：",
+      "  1. 有明确更好的做法，不是'换个样子试试'",
+      "  2. 说得出具体好在哪，最好有对照证据",
+      "  3. 改完写进本文件的 changelog 字段，并同步 leo-vault 内容交付标准 SSOT",
+      "低频。默认是不动。",
+      "",
+      "这条锁存在的原因：同一批工作里，封面版式、片尾内容、图表配色各被改了两三次，",
+      "每次都是临时决定、留在某一条片子的 script.json 里 —— 下一条片子看不到，于是又重新决定一次。",
+      "两条一周内做的片子因此长得不像一个产品。"
+    ],
+    "changelog": [
+      "2026-08-18 定稿：封面 = CoverArt（左结论右证据，数据图与片内同源）；片尾 = endCard 四条署名"
+    ],
+    "cover": {
+      "composition": "CoverArt",
+      "layout": "左 44% 结论（eyebrow + 标题 + 副标题 + 数据口径脚注），右 56% 证据图表",
+      "renderFrame": 75,
+      "$renderFrameNote": "图表靠 spring 生长，frame 0 时柱子为空。必须渲动画收敛后的帧。",
+      "specs": {
+        "16x9": [
+          1920,
+          1080
+        ],
+        "9x16": [
+          1080,
+          1920
+        ],
+        "xhs4x3": [
+          1440,
+          1080
+        ]
+      },
+      "personaRule": "PM/预测市场类内容封面**不带**虚拟形象；非 PM 类才带（2026-07-29 规定，08-12 加例外）"
+    },
+    "endCard": {
+      "$comment": "末镜固定署名。片子如无特殊理由一律用这四条，不要每条片子重新想。",
+      "enabled": true,
+      "ctas": [
+        {
+          "label": "作者",
+          "value": "Leo · 一个人 + AI"
+        },
+        {
+          "label": "研究",
+          "value": "leolabs.me"
+        },
+        {
+          "label": "X",
+          "value": "@runes_leo"
+        },
+        {
+          "label": "频道",
+          "value": "t.me/runesgangalpha"
+        }
+      ],
+      "excluded": "不放返佣、订阅、课程 —— 那些属于分发文案，不进片子。个别片子要放须在 PREPRODUCTION-GATE 写明理由。"
+    }
   }
 }

--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -421,6 +421,24 @@ export const Root: React.FC = () => {
       defaultProps={DEFAULT_COVER}
     />
     <Composition
+      id="CoverArt9x16"
+      component={CoverArt}
+      durationInFrames={90}
+      fps={30}
+      width={1080}
+      height={1920}
+      defaultProps={DEFAULT_COVER}
+    />
+    <Composition
+      id="CoverArt4x3"
+      component={CoverArt}
+      durationInFrames={90}
+      fps={30}
+      width={1440}
+      height={1080}
+      defaultProps={DEFAULT_COVER}
+    />
+    <Composition
       id="Main"
       component={Main}
       durationInFrames={1}

--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -93,6 +93,8 @@ type SlideMeta = {
   body?: string;
   badge?: string;
   badgeGradient?: [string, string];
+  /** CN 平台版：按 T288 去掉 TG 等信号入口 */
+  cnPlatform?: boolean;
 
   // table
   tableData?: {
@@ -235,6 +237,7 @@ const Main: React.FC<Metadata> = (meta) => {
                 logoSrc={slide.logoSrc ?? meta.brand?.logoSrc}
                 endCard={slide.endCard}
                 endCardCTAs={slide.endCardCTAs}
+                cnPlatform={slide.cnPlatform}
               />
             )}
             {slide.type === "text" && (

--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -23,6 +23,7 @@ import { CaptionsLayer, CaptionPosition } from "./compositions/CaptionsLayer";
 import { BrandConfig } from "./compositions/BrandedSlideLayout";
 import { Preset, resolvePreset } from "./presets";
 import { UiKitDemo } from "./ui-kit/UiKitDemo";
+import { CoverArt, CoverArtProps } from "./compositions/CoverArt";
 import { OkxAspDemo, defaultOkxAspDemoProps, type OkxAspDemoProps } from "./ui-kit/OkxAspDemo";
 
 /**
@@ -397,9 +398,28 @@ const Main: React.FC<Metadata> = (meta) => {
 const calcDuration = (m: Metadata) =>
   m.slides.reduce((acc, s) => acc + s.durationInFrames, 0);
 
+const DEFAULT_COVER: CoverArtProps = {
+  eyebrow: "COVER",
+  title: "标题第一行\n标题第二行",
+  subtitle: "副标题",
+};
+
 export const Root: React.FC = () => {
   return (
     <>
+    {/* 数据封面：左结论右证据，图表组件与片内同源，色板同一份 design-system.json。
+        用 `remotion still src/index.ts CoverArt <out.png> --props=...` 渲染。 */}
+    <Composition
+      id="CoverArt"
+      component={CoverArt}
+      // 图表组件靠 spring 生长，frame 0 时柱子宽度为 0、数值 opacity 为 0 ——
+      // 封面是静态图，必须渲动画收敛之后的帧。留 90 帧，渲 --frame=75。
+      durationInFrames={90}
+      fps={30}
+      width={1920}
+      height={1080}
+      defaultProps={DEFAULT_COVER}
+    />
     <Composition
       id="Main"
       component={Main}

--- a/remotion/src/compositions/CoverArt.tsx
+++ b/remotion/src/compositions/CoverArt.tsx
@@ -1,0 +1,160 @@
+/**
+ * CoverArt — 数据封面：左边说结论，右边给证据。
+ *
+ * 为什么不用纯文字大标题（2026-08-18）：
+ * kit 原本只有 `gen_video_cover.py`，它只会把标题放大铺满。而实际效果最好的那张封面
+ * （另一条片子自研的 290 行 PIL 脚本）是左文字右数据图表 —— 封面本身就在证明标题。
+ * 那个脚本把数据源硬编码成了具体的 csv/parquet 路径，无法复用，于是后来的片子只能退回
+ * 纯文字模板：**好的做法留在了某一条片子里，管线里没有。**
+ *
+ * 这里改成用片内已有的图表组件渲封面：色板自动一致（同一份 design-system.json），
+ * 数据直接取自 script.json 的图表镜，不再有第二套硬编码。
+ *
+ * 用法（remotion still）：
+ *   remotion still src/index.ts CoverArt out/cover-16x9.png --props='{...}'
+ */
+import React from "react";
+import { AbsoluteFill } from "remotion";
+import ds from "../../../config/design-system.json";
+import { BarCompare, BarItem } from "./charts/BarCompare";
+import { ThresholdGrid, ThresholdCell } from "./charts/ThresholdGrid";
+
+const DS = {
+  canvas: ds.canvas.base,
+  text: ds.text.primary,
+  muted: ds.text.muted,
+  accent: ds.semantic.accent,
+  sans: ds.typography.sans.join(", "),
+  mono: ds.typography.mono.join(", "),
+};
+
+export type CoverArtProps = {
+  eyebrow?: string;
+  /** 主标题。用 \n 手动断行 —— 封面标题的断行位置是语义的，不交给自动折行。 */
+  title: string;
+  /** 强调片段：title 里出现的这段文字用强调色。 */
+  highlight?: string;
+  subtitle?: string;
+  footnote?: string;
+  watermark?: string;
+  /** 右侧证据图。省略则退化为纯文字封面（版式仍与片内一致）。 */
+  chart?:
+    | { type: "barCompare"; items: BarItem[]; unit?: string; decimals?: number }
+    | { type: "thresholdGrid"; cells: ThresholdCell[]; verdict?: string };
+};
+
+export const CoverArt: React.FC<CoverArtProps> = ({
+  eyebrow,
+  title,
+  highlight,
+  subtitle,
+  footnote,
+  watermark = ds.cover.watermark,
+  chart,
+}) => {
+  const lines = title.split("\n");
+  return (
+    <AbsoluteFill style={{ background: DS.canvas, fontFamily: DS.sans, color: DS.text }}>
+      {/* 顶部品牌渐变条 —— 与片内一致 */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 6,
+          background: `linear-gradient(90deg, ${ds.semantic.verified}, ${ds.semantic.accent})`,
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          background: `radial-gradient(1200px 700px at 22% 42%, ${ds.semantic.accent}14, transparent 70%)`,
+        }}
+      />
+
+      <div style={{ display: "flex", height: "100%", padding: "96px 110px", gap: 56 }}>
+        {/* 左：结论 */}
+        <div
+          style={{
+            flex: chart ? "0 0 44%" : "1",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+          }}
+        >
+          {eyebrow && (
+            <div
+              style={{
+                fontSize: 28,
+                color: DS.accent,
+                fontFamily: DS.mono,
+                letterSpacing: "0.14em",
+                marginBottom: 26,
+              }}
+            >
+              {eyebrow}
+            </div>
+          )}
+          <div style={{ fontSize: 80, fontWeight: 900, lineHeight: 1.2, letterSpacing: "-0.035em" }}>
+            {lines.map((ln, i) => (
+              <div key={i}>
+                {highlight && ln.includes(highlight) ? (
+                  <>
+                    {ln.split(highlight)[0]}
+                    <span style={{ color: DS.accent }}>{highlight}</span>
+                    {ln.split(highlight)[1]}
+                  </>
+                ) : (
+                  ln
+                )}
+              </div>
+            ))}
+          </div>
+          {subtitle && (
+            <div style={{ fontSize: 32, color: DS.muted, marginTop: 28, lineHeight: 1.45 }}>
+              {subtitle}
+            </div>
+          )}
+          {footnote && (
+            <div style={{ fontSize: 23, color: DS.muted, fontFamily: DS.mono, marginTop: 32 }}>
+              {footnote}
+            </div>
+          )}
+        </div>
+
+        {/* 右：证据。封面自己就在证明标题，而不是只喊一句口号。 */}
+        {chart && (
+          <div style={{ flex: 1, display: "flex", alignItems: "center", minWidth: 0 }}>
+            {chart.type === "barCompare" && (
+              <BarCompare
+                bare
+                title=""
+                items={chart.items}
+                unit={chart.unit}
+                decimals={chart.decimals}
+              />
+            )}
+            {chart.type === "thresholdGrid" && (
+              <ThresholdGrid bare title="" cells={chart.cells} verdict={chart.verdict} />
+            )}
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          position: "absolute",
+          bottom: 46,
+          right: 110,
+          fontSize: 24,
+          color: DS.muted,
+          fontFamily: DS.mono,
+        }}
+      >
+        {watermark}
+      </div>
+    </AbsoluteFill>
+  );
+};

--- a/remotion/src/compositions/CoverArt.tsx
+++ b/remotion/src/compositions/CoverArt.tsx
@@ -14,7 +14,7 @@
  *   remotion still src/index.ts CoverArt out/cover-16x9.png --props='{...}'
  */
 import React from "react";
-import { AbsoluteFill } from "remotion";
+import { AbsoluteFill, useVideoConfig } from "remotion";
 import ds from "../../../config/design-system.json";
 import { BarCompare, BarItem } from "./charts/BarCompare";
 import { ThresholdGrid, ThresholdCell } from "./charts/ThresholdGrid";
@@ -53,6 +53,18 @@ export const CoverArt: React.FC<CoverArtProps> = ({
   chart,
 }) => {
   const lines = title.split("\n");
+  const { width, height } = useVideoConfig();
+  // 竖版（9:16）左右分栏会把两边都挤扁 —— 改成上下：结论在上，证据在下。
+  // 判据用宽高比而不是具体尺寸，这样 4:3、1:1 之类也能落到正确的那一支。
+  const ratio = width / height;
+  const portrait = ratio < 0.9;          // 9:16 才走上下分栏
+  const narrow = ratio >= 0.9 && ratio < 1.5;  // 4:3 仍是左右，但可用横向空间少得多
+  const pad = portrait ? "150px 90px" : narrow ? "80px 76px" : "96px 110px";
+  // 竖版整幅只放一栏，字号可以大；4:3 左右都要挤，标题必须收下来否则被折成四行。
+  const titleSize = portrait ? 104 : narrow ? 62 : 80;
+  const subSize = portrait ? 40 : narrow ? 27 : 32;
+  const footSize = portrait ? 27 : narrow ? 20 : 23;
+  const eyebrowSize = portrait ? 34 : narrow ? 23 : 28;
   return (
     <AbsoluteFill style={{ background: DS.canvas, fontFamily: DS.sans, color: DS.text }}>
       {/* 顶部品牌渐变条 —— 与片内一致 */}
@@ -74,11 +86,11 @@ export const CoverArt: React.FC<CoverArtProps> = ({
         }}
       />
 
-      <div style={{ display: "flex", height: "100%", padding: "96px 110px", gap: 56 }}>
+      <div style={{ display: "flex", flexDirection: portrait ? "column" : "row", height: "100%", padding: pad, gap: portrait ? 72 : 56 }}>
         {/* 左：结论 */}
         <div
           style={{
-            flex: chart ? "0 0 44%" : "1",
+            flex: chart ? (portrait ? "0 0 42%" : narrow ? "0 0 47%" : "0 0 44%") : "1",
             display: "flex",
             flexDirection: "column",
             justifyContent: "center",
@@ -87,7 +99,7 @@ export const CoverArt: React.FC<CoverArtProps> = ({
           {eyebrow && (
             <div
               style={{
-                fontSize: 28,
+                fontSize: eyebrowSize,
                 color: DS.accent,
                 fontFamily: DS.mono,
                 letterSpacing: "0.14em",
@@ -97,7 +109,7 @@ export const CoverArt: React.FC<CoverArtProps> = ({
               {eyebrow}
             </div>
           )}
-          <div style={{ fontSize: 80, fontWeight: 900, lineHeight: 1.2, letterSpacing: "-0.035em" }}>
+          <div style={{ fontSize: titleSize, fontWeight: 900, lineHeight: 1.2, letterSpacing: "-0.035em" }}>
             {lines.map((ln, i) => (
               <div key={i}>
                 {highlight && ln.includes(highlight) ? (
@@ -113,12 +125,12 @@ export const CoverArt: React.FC<CoverArtProps> = ({
             ))}
           </div>
           {subtitle && (
-            <div style={{ fontSize: 32, color: DS.muted, marginTop: 28, lineHeight: 1.45 }}>
+            <div style={{ fontSize: subSize, color: DS.muted, marginTop: 26, lineHeight: 1.45 }}>
               {subtitle}
             </div>
           )}
           {footnote && (
-            <div style={{ fontSize: 23, color: DS.muted, fontFamily: DS.mono, marginTop: 32 }}>
+            <div style={{ fontSize: footSize, color: DS.muted, fontFamily: DS.mono, marginTop: 28 }}>
               {footnote}
             </div>
           )}
@@ -147,7 +159,7 @@ export const CoverArt: React.FC<CoverArtProps> = ({
         style={{
           position: "absolute",
           bottom: 46,
-          right: 110,
+          right: portrait ? 84 : 110,
           fontSize: 24,
           color: DS.muted,
           fontFamily: DS.mono,

--- a/remotion/src/compositions/CoverSlide.tsx
+++ b/remotion/src/compositions/CoverSlide.tsx
@@ -30,6 +30,7 @@ interface CoverSlideProps {
   logoSrc?: string;
   /** EndCard mode: shows multi-platform CTA row (X / site / channel) below subtitle. */
   endCard?: boolean;
+  cnPlatform?: boolean;
   /** EndCard CTAs (3 lines). */
   endCardCTAs?: { label: string; value: string }[];
 }
@@ -52,7 +53,9 @@ export const CoverSlide: React.FC<CoverSlideProps> = ({
   endCard = false,
   // 末镜署名固定取自 design-system.json 的模板锁 —— 不再每条片子手填。
   // 见该文件 template.$comment：模板定稿后低频变更，默认不动。
-  endCardCTAs = ds.template?.endCard?.ctas,
+  endCardCTAs,
+  /** CN 平台版片尾：按 T288，B站/小红书/抖音/视频号不得出现 TG 等信号入口。 */
+  cnPlatform = false,
 }) => {
   const frame = useCurrentFrame();
   const { fps, durationInFrames } = useVideoConfig();
@@ -77,6 +80,8 @@ export const CoverSlide: React.FC<CoverSlideProps> = ({
     extrapolateRight: "clamp",
   });
 
+  const resolvedCTAs =
+    endCardCTAs ?? (cnPlatform ? ds.template?.endCard?.ctas_cn : ds.template?.endCard?.ctas);
   const titleFont = (endCard ? 92 : 80) * fontScale;
   const subtitleFont = 40 * fontScale;
   const eyebrowFont = 22 * fontScale;
@@ -158,7 +163,7 @@ export const CoverSlide: React.FC<CoverSlideProps> = ({
             {subtitle}
           </div>
         )}
-        {endCard && endCardCTAs && endCardCTAs.length > 0 && (
+        {endCard && resolvedCTAs && resolvedCTAs.length > 0 && (
           <div
             style={{
               opacity: ctaOpacity,
@@ -172,7 +177,7 @@ export const CoverSlide: React.FC<CoverSlideProps> = ({
               alignItems: "center",
             }}
           >
-            {endCardCTAs.map((cta, i) => (
+            {resolvedCTAs.map((cta, i) => (
               <div
                 key={i}
                 style={{

--- a/remotion/src/compositions/CoverSlide.tsx
+++ b/remotion/src/compositions/CoverSlide.tsx
@@ -9,6 +9,7 @@ import {
   useVideoConfig,
 } from "remotion";
 import { LEO_LOGO_DATA_URL } from "./leoLogoData";
+import ds from "../../../config/design-system.json";
 
 interface CoverSlideProps {
   title: string;
@@ -49,7 +50,9 @@ export const CoverSlide: React.FC<CoverSlideProps> = ({
   watermarkUrl = "leolabs.me",
   logoSrc,
   endCard = false,
-  endCardCTAs,
+  // 末镜署名固定取自 design-system.json 的模板锁 —— 不再每条片子手填。
+  // 见该文件 template.$comment：模板定稿后低频变更，默认不动。
+  endCardCTAs = ds.template?.endCard?.ctas,
 }) => {
   const frame = useCurrentFrame();
   const { fps, durationInFrames } = useVideoConfig();

--- a/remotion/src/compositions/CoverSlide.tsx
+++ b/remotion/src/compositions/CoverSlide.tsx
@@ -159,10 +159,13 @@ export const CoverSlide: React.FC<CoverSlideProps> = ({
           <div
             style={{
               opacity: ctaOpacity,
-              marginTop: 56,
+              // 上移并压缩行距：CaptionsLayer 覆盖在所有镜之上，基线距画布底 96px。
+              // 末镜的口播仍在进行，字幕会盖住最后一条 CTA —— 实测「频道」那行被压。
+              marginTop: 40,
+              marginBottom: 96,
               display: "flex",
               flexDirection: "column",
-              gap: 18,
+              gap: 14,
               alignItems: "center",
             }}
           >

--- a/remotion/src/compositions/charts/BarCompare.tsx
+++ b/remotion/src/compositions/charts/BarCompare.tsx
@@ -46,9 +46,10 @@ const BarRow: React.FC<{
   max: number;
   rowH: number;
   delay: number;
+  compact: boolean;
   unit: string;
   decimals: number;
-}> = ({ item, max, rowH, delay, unit, decimals }) => {
+}> = ({ item, max, rowH, delay, unit, decimals, compact }) => {
   const g = useGrow(delay);
   const n = useCountUp(item.value, delay);
   const w = interpolate(g, [0, 1], [0, (item.value / max) * 100]);
@@ -59,8 +60,8 @@ const BarRow: React.FC<{
     <div style={{ display: "flex", alignItems: "center", gap: 26, height: rowH }}>
       <div
         style={{
-          flex: "0 0 430px",
-          fontSize: 29,
+          flex: compact ? "0 0 210px" : "0 0 430px",
+          fontSize: compact ? 22 : 29,
           textAlign: "right",
           color: emphasised ? DS.text : DS.muted,
           fontWeight: emphasised ? 700 : 400,
@@ -69,7 +70,7 @@ const BarRow: React.FC<{
         {item.label}
       </div>
       {/* 右侧留白：数值+注释画在条形末端外侧，条形区必须留出空间，否则最长的一条会被画布右缘裁掉 */}
-      <div style={{ flex: 1, position: "relative", height: rowH * 0.58, marginRight: 300 }}>
+      <div style={{ flex: 1, position: "relative", height: rowH * 0.58, marginRight: compact ? 150 : 300 }}>
         <div style={{ position: "absolute", inset: 0, background: DS.panel, borderRadius: 10 }} />
         <div
           style={{
@@ -89,7 +90,7 @@ const BarRow: React.FC<{
             left: `calc(${w}% + 22px)`,
             top: "50%",
             transform: "translateY(-50%)",
-            fontSize: 34,
+            fontSize: compact ? 27 : 34,
             fontWeight: 800,
             fontFamily: DS.mono,
             color: emphasised ? c : DS.muted,
@@ -142,6 +143,7 @@ export const BarCompare: React.FC<{
             max={max}
             rowH={rowH}
             delay={8 + i * 7}
+            compact={Boolean(bare)}
             unit={unit}
             decimals={decimals}
           />

--- a/remotion/src/compositions/charts/BarCompare.tsx
+++ b/remotion/src/compositions/charts/BarCompare.tsx
@@ -116,10 +116,12 @@ export const BarCompare: React.FC<{
   footnote?: string;
   slideNumber?: number;
   totalSlides?: number;
+  /** 裸模式：封面等场景只要图表主体 */
+  bare?: boolean;
   items: BarItem[];
   unit?: string;
   decimals?: number;
-}> = ({ title, subtitle, footnote, slideNumber, totalSlides, items, unit = "", decimals = 1 }) => {
+}> = ({ title, subtitle, footnote, slideNumber, totalSlides, items, unit = "", decimals = 1, bare }) => {
   const max = Math.max(...items.map((i) => i.value), 1);
   const rowH = Math.min(112, 560 / Math.max(items.length, 1));
 
@@ -130,6 +132,7 @@ export const BarCompare: React.FC<{
       footnote={footnote}
       slideNumber={slideNumber}
       totalSlides={totalSlides}
+      bare={bare}
     >
       <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: 18 }}>
         {items.map((it, i) => (

--- a/remotion/src/compositions/charts/ThresholdGrid.tsx
+++ b/remotion/src/compositions/charts/ThresholdGrid.tsx
@@ -78,9 +78,11 @@ export const ThresholdGrid: React.FC<{
   footnote?: string;
   slideNumber?: number;
   totalSlides?: number;
+  /** 裸模式：封面等场景只要图表主体 */
+  bare?: boolean;
   cells: ThresholdCell[];
   verdict?: string;
-}> = ({ title, subtitle, footnote, slideNumber, totalSlides, cells, verdict }) => {
+}> = ({ title, subtitle, footnote, slideNumber, totalSlides, cells, verdict, bare }) => {
   const gVerdict = useGrow(12 + cells.length * 8);
   return (
     <ChartFrame
@@ -89,6 +91,7 @@ export const ThresholdGrid: React.FC<{
       footnote={footnote}
       slideNumber={slideNumber}
       totalSlides={totalSlides}
+      bare={bare}
     >
       <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: 40 }}>
         <div style={{ display: "flex", gap: 24 }}>

--- a/remotion/src/compositions/charts/chartBase.tsx
+++ b/remotion/src/compositions/charts/chartBase.tsx
@@ -54,28 +54,33 @@ export const ChartFrame: React.FC<{
   footnote?: string;
   slideNumber?: number;
   totalSlides?: number;
+  /** 裸模式：只画图表主体，不画标题栏/页码/脚注/字幕带。
+      封面用 —— 封面自己有标题排版，图表在那里是证据不是主角。 */
+  bare?: boolean;
   children: React.ReactNode;
-}> = ({ title, subtitle, footnote, slideNumber, totalSlides, children }) => {
+}> = ({ title, subtitle, footnote, slideNumber, totalSlides, bare = false, children }) => {
   const t = useGrow(0);
   return (
     <div
       style={{
         width: "100%",
         height: "100%",
-        background: DS.canvas,
-        padding: `${DS.safeY}px ${DS.safeX}px`,
+        background: bare ? "transparent" : DS.canvas,
+        padding: bare ? 0 : `${DS.safeY}px ${DS.safeX}px`,
         display: "flex",
         flexDirection: "column",
         fontFamily: DS.sans,
         color: DS.text,
       }}
     >
-      <div style={{ opacity: t, transform: `translateY(${interpolate(t, [0, 1], [18, 0])}px)` }}>
-        <div style={{ fontSize: 58, fontWeight: 800, letterSpacing: "-0.03em" }}>{title}</div>
-        {subtitle && (
-          <div style={{ fontSize: 30, color: DS.muted, marginTop: 12 }}>{subtitle}</div>
-        )}
-      </div>
+      {!bare && (
+        <div style={{ opacity: t, transform: `translateY(${interpolate(t, [0, 1], [18, 0])}px)` }}>
+          <div style={{ fontSize: 58, fontWeight: 800, letterSpacing: "-0.03em" }}>{title}</div>
+          {subtitle && (
+            <div style={{ fontSize: 30, color: DS.muted, marginTop: 12 }}>{subtitle}</div>
+          )}
+        </div>
+      )}
 
       {/* CaptionsLayer 覆盖在所有镜之上，其基线距画布底 96px（design-system.layout）。
           文字卡不受影响，但图表会被字幕压住 —— 实测柱状条与散点云都被遮过。
@@ -86,12 +91,13 @@ export const ChartFrame: React.FC<{
           display: "flex",
           alignItems: "center",
           marginTop: 36,
-          paddingBottom: CAPTION_BAND,
+          paddingBottom: bare ? 0 : CAPTION_BAND,
         }}
       >
         {children}
       </div>
 
+      {!bare && (
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end" }}>
         <div style={{ fontSize: 22, color: DS.muted, fontFamily: DS.mono, maxWidth: 1300 }}>
           {footnote}
@@ -102,6 +108,7 @@ export const ChartFrame: React.FC<{
           </div>
         )}
       </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Follow-on to #23. Three things, all from shipping one real video and finding what the pipeline could not do.

**Data covers.** The cover generator only enlarged a title to fill the frame. The best cover produced so far — conclusion on the left, data chart on the right, so the cover argues its own headline — came from a 290-line PIL script inside one project with its data sources hard-coded to specific file paths. Unreusable, so later videos fell back to plain text. `CoverArt` now renders covers from the same chart components the video body uses: palette from `design-system.json`, data from the deck's own chart slides. Note it runs 90 frames rather than 1 — the charts grow with a spring, so a still at frame 0 renders empty bars.

**Responsive layouts.** One layout does not survive three aspect ratios. Side-by-side columns squash both halves at 9:16, and at 4:3 the title folded to four lines while a chart note ran off-canvas. Splits on aspect ratio: portrait stacks conclusion over evidence, narrow landscape keeps columns with smaller type, and charts gain a compact mode.

**Platform-specific end cards.** The end card carried a Telegram handle — fine on X and YouTube, but mainland-China video platforms prohibit off-platform signal entry points, and one video shipped to Bilibili with it. `ctas_cn` keeps author and research site only. Worth noting why it slipped: the deck's own gate said "no affiliate or course promotion in-video" and that was satisfied; the channel-level policy lived in a separate document nothing in the render path referenced.

**Template lock.** Within a single batch, cover layout, end card and chart palette were each redone two or three times, every decision left inside one deck's `script.json` where the next deck could not see it. The template block in `design-system.json` now holds these and states a change policy: fixed once, changed rarely, only for a demonstrably better approach with the reason recorded.

CI: `npm run check` green locally.